### PR TITLE
persistent sockets and retrying in _send_receive on exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ Classes
         dev_type (str): Device type for payload options (see below)
 
  Functions 
-    json = status()          # returns json payload
-    set_version(version)     #  3.1 [default] or 3.3
-    set_dpsUsed(dpsUsed)     # set data points (DPs)
-    set_retry(retry=True)    # retry if response payload is truncated
-    set_status(on, switch=1) # Set status of the device to 'on' or 'off' (bool)
-    set_value(index, value)  # Set int value of any index.
+    json = status()                    # returns json payload
+    set_version(version)               # 3.1 [default] or 3.3
+    set_socketPersistent(False/True)   # False [default] or True
+    set_socketNODELAY(False/True)      # False or True [default]
+    set_dpsUsed(dpsUsed)               # set data points (DPs)
+    set_retry(retry=True)              # retry if response payload is truncated
+    set_status(on, switch=1)           # Set status of the device to 'on' or 'off' (bool)
+    set_value(index, value)            # Set int value of any index.
     turn_on(switch=1):
     turn_off(switch=1):
     set_timer(num_secs):
@@ -88,6 +90,7 @@ Classes
         set_white(brightness, colourtemp):
         set_brightness(brightness):
         set_colourtemp(colourtemp):
+        set_scene(scene):             # 1=nature, 3=rave, 4=rainbow
         result = brightness():
         result = colourtemp():
         (r, g, b) = colour_rgb():

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -292,7 +292,7 @@ class XenonDevice(object):
         if(self.socket==None):
           self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
           if(self.socketNODELAY):
-            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
           self.socket.settimeout(self.connection_timeout)
           self.socket.connect((self.address, self.port))
 
@@ -316,10 +316,11 @@ class XenonDevice(object):
                 data = self.socket.recv(1024)  # try again
             success=True
             # Legacy/default mode avoids persisting socket across commands
-            if(self.socketPersistent==False):
+            if(not self.socketPersistent):
               self.socket.close()
               self.socket=None
           except:
+            #print('Exception with low level TinyTuya socket!!! will retry!!!')
             log.exception('Exception with low level TinyTuya socket!!! will retry!!!')
             time.sleep(0.1)
             # toss old socket and get new one


### PR DESCRIPTION
For #2 

The retrying mode in _send_receive() always happens with this change.  When it has to retry, it sends a log.exception() message.  Some people may want to squash it but thats the level it is set to now.

To change persistence[False] and NODELAY[True] behavior from previous defaults:

tuya=tinytuya.BulbDevice('bulb_id_here','ip_addr_here','key_here')
tuya.set_version(3.3)
tuya.set_socketNODELAY(False)
tuya.set_socketPersistent(True)

I tested with my control app and with a cycle of 2000 status requests.

If merged, please let me know when a new release goes out to pip so I can switch from using my custom build.