### PR TITLE
add set_socketRetryLimit(integer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Classes
     set_version(version)               # 3.1 [default] or 3.3
     set_socketPersistent(False/True)   # False [default] or True
     set_socketNODELAY(False/True)      # False or True [default]
+    set_socketRetryLimit(integer)      # retry count limit [default 5]
     set_dpsUsed(dpsUsed)               # set data points (DPs)
     set_retry(retry=True)              # retry if response payload is truncated
     set_status(on, switch=1)           # Set status of the device to 'on' or 'off' (bool)


### PR DESCRIPTION
More for #2.  Extends #6 

Adds
set_socketRetryLimit(integer)      # retry count limit [default 5]

If retry limit is exceeded, the exception will be rethrown up to the client app.

to remove all retries set retry limit to 0 (or a negative number).  Will then see 10054 error on susceptible systems.

Error generating case for me:

```python
tuya.set_version(3.3)
#tuya.set_socketNODELAY(False)
#tuya.set_socketPersistent(True)
tuya.set_socketRetryLimit(0)
for i in range(2000):
    data=tuya.status()
    if(data['dps']['1']==False):
        print(str(i)+": off")
    else:
        print(str(i)+": on")
```

Working case for me is with the default 5 (I haven't seen more than like 2 retries under limited testing)

```python
tuya.set_version(3.3)
tuya.set_socketNODELAY(False)
tuya.set_socketPersistent(True)
#tuya.set_socketRetryLimit(0)
for i in range(2000):
    data=tuya.status()
    if(data['dps']['1']==False):
        print(str(i)+": off")
    else:
        print(str(i)+": on")
```