### PR TITLE
Emit error rather than crash

### DIFF
--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -1551,6 +1551,9 @@ class BulbDevice(Device):
         if not status:
             return error_json(ERR_JSON,"state: empty response")
 
+        if 'Error' in status.keys():
+            return status
+
         for key in status[self.DPS].keys():
             if(key in self.DPS_2_STATE):
                 state[self.DPS_2_STATE[key]] = status[self.DPS][key]


### PR DESCRIPTION
In my situation, I am getting "Error" in my status, but not "dps".  The status packet looks a lot like the one generated by error_json, so returning it seems logical.  The only caveat here is that I cannot get my device to work, so I am not certain that there is no Error in a valid status message, though it seems unlikely.  If it is there, you could add a check to ensure "dps" is missing, but I suspect that will be unnecessary.