### PR TITLE
Some cleanup from pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MESSAGES CONTROL]
+disable=bad-whitespace, consider-iterating-dictionary, import-error, invalid-name, missing-docstring, no-else-return, no-member, too-many-lines, line-too-long, too-many-ancestors, too-many-arguments, too-many-branches, too-many-instance-attributes, too-many-locals, too-many-nested-blocks, too-many-return-statements, too-many-statements, too-few-public-methods, ungrouped-imports, use-dict-literal
+
+[SIMILARITIES]
+min-similarity-lines=8

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -1489,7 +1489,7 @@ class BulbDevice(Device):
             colourtemp(int): Value for the colour temperature in percent (0-100)
         """
         # Brightness
-        if not (0 <= brightness <= 100):
+        if not 0 <= brightness <= 100:
             return error_json(
                 ERR_RANGE,
                 "set_white_percentage: Brightness percentage needs to be between 0 and 100.",
@@ -1501,7 +1501,7 @@ class BulbDevice(Device):
             b = int(10 + (1000 - 10) * brightness / 100)
 
         # Colourtemp
-        if not (0 <= colourtemp <= 100):
+        if not 0 <= colourtemp <= 100:
             return error_json(
                 ERR_RANGE,
                 "set_white_percentage: Colourtemp percentage needs to be between 0 and 100.",
@@ -1530,11 +1530,11 @@ class BulbDevice(Device):
             brightness = 255
             if self.bulb_type == "B":
                 brightness = 1000
-        if self.bulb_type == "A" and not (25 <= brightness <= 255):
+        if self.bulb_type == "A" and not 25 <= brightness <= 255:
             return error_json(
                 ERR_RANGE, "set_white: The brightness needs to be between 25 and 255."
             )
-        if self.bulb_type == "B" and not (10 <= brightness <= 1000):
+        if self.bulb_type == "B" and not 10 <= brightness <= 1000:
             return error_json(
                 ERR_RANGE, "set_white: The brightness needs to be between 10 and 1000."
             )
@@ -1542,12 +1542,12 @@ class BulbDevice(Device):
         # Colourtemp (default Min)
         if colourtemp < 0:
             colourtemp = 0
-        if self.bulb_type == "A" and not (0 <= colourtemp <= 255):
+        if self.bulb_type == "A" and not 0 <= colourtemp <= 255:
             return error_json(
                 ERR_RANGE,
                 "set_white: The colour temperature needs to be between 0 and 255.",
             )
-        if self.bulb_type == "B" and not (0 <= colourtemp <= 1000):
+        if self.bulb_type == "B" and not 0 <= colourtemp <= 1000:
             return error_json(
                 ERR_RANGE,
                 "set_white: The colour temperature needs to be between 0 and 1000.",
@@ -1572,7 +1572,7 @@ class BulbDevice(Device):
         Args:
             brightness(int): Value for the brightness in percent (0-100)
         """
-        if not (0 <= brightness <= 100):
+        if not 0 <= brightness <= 100:
             return error_json(
                 ERR_RANGE,
                 "set_brightness_percentage: Brightness percentage needs to be between 0 and 100.",
@@ -1591,12 +1591,12 @@ class BulbDevice(Device):
         Args:
             brightness(int): Value for the brightness (25-255).
         """
-        if self.bulb_type == "A" and not (25 <= brightness <= 255):
+        if self.bulb_type == "A" and not 25 <= brightness <= 255:
             return error_json(
                 ERR_RANGE,
                 "set_brightness: The brightness needs to be between 25 and 255.",
             )
-        if self.bulb_type == "B" and not (10 <= brightness <= 1000):
+        if self.bulb_type == "B" and not 10 <= brightness <= 1000:
             return error_json(
                 ERR_RANGE,
                 "set_brightness: The brightness needs to be between 10 and 1000.",
@@ -1639,7 +1639,7 @@ class BulbDevice(Device):
         Args:
             colourtemp(int): Value for the colour temperature in percentage (0-100).
         """
-        if not (0 <= colourtemp <= 100):
+        if not 0 <= colourtemp <= 100:
             return error_json(
                 ERR_RANGE,
                 "set_colourtemp_percentage: Colourtemp percentage needs to be between 0 and 100.",
@@ -1662,12 +1662,12 @@ class BulbDevice(Device):
             return error_json(
                 ERR_FUNCTION, "set_colourtemp: Device does not support colortemp."
             )
-        if self.bulb_type == "A" and not (0 <= colourtemp <= 255):
+        if self.bulb_type == "A" and not 0 <= colourtemp <= 255:
             return error_json(
                 ERR_RANGE,
                 "set_colourtemp: The colour temperature needs to be between 0 and 255.",
             )
-        if self.bulb_type == "B" and not (0 <= colourtemp <= 1000):
+        if self.bulb_type == "B" and not 0 <= colourtemp <= 1000:
             return error_json(
                 ERR_RANGE,
                 "set_colourtemp: The colour temperature needs to be between 0 and 1000.",
@@ -1778,7 +1778,7 @@ def termcolor(color=True):
         cyan = "\033[0m\033[36m"
         red = "\033[0m\033[31m"
         yellow = "\033[0m\033[33m"
-    return(bold,subbold,normal,dim,alert,alertdim,cyan,red,yellow)
+    return bold,subbold,normal,dim,alert,alertdim,cyan,red,yellow
 
 
 # Scan function shortcut
@@ -1890,15 +1890,15 @@ class Cloud(object):
             apiRegion = self.apiRegion
         self.apiRegion = apiRegion.lower()
         self.urlhost = "openapi.tuyacn.com"          # China Data Center
-        if(self.apiRegion == "us"):
+        if self.apiRegion == "us":
             self.urlhost = "openapi.tuyaus.com"      # Western America Data Center
-        if(self.apiRegion == "us-e"):
+        if self.apiRegion == "us-e":
             self.urlhost = "openapi-ueaz.tuyaus.com" # Eastern America Data Center
-        if(self.apiRegion == "eu"):
+        if self.apiRegion == "eu":
             self.urlhost = "openapi.tuyaeu.com"      # Central Europe Data Center
-        if(self.apiRegion == "eu-w"):
+        if self.apiRegion == "eu-w":
             self.urlhost = "openapi-weaz.tuyaeu.com" # Western Europe Data Center
-        if(self.apiRegion == "in"):
+        if self.apiRegion == "in":
             self.urlhost = "openapi.tuyain.com"      # India Datacenter
 
     def _tuyaplatform(self, uri, action='GET', post=None, ver='v1.0', recursive=False):
@@ -1916,7 +1916,7 @@ class Cloud(object):
             action = 'GET'
         now = int(time.time()*1000)
         headers = dict(list(headers.items()) + [('Signature-Headers', ":".join(headers.keys()))]) if headers else {}
-        if(self.token==None):
+        if self.token==None:
             payload = self.apiKey + str(now)
             headers['secret'] = self.apiSecret
         else:
@@ -1943,7 +1943,7 @@ class Cloud(object):
         headers['t'] = str(now)
         headers['sign_method'] = 'HMAC-SHA256'
 
-        if(self.token != None):
+        if self.token != None:
             headers['access_token'] = self.token
 
         # Send Request to Cloud and Get Response
@@ -1982,7 +1982,7 @@ class Cloud(object):
                     "Cloud _tuyaplatform() invalid response: %r" % response.content,
                 )
         # Check to see if token is expired
-        return(response_dict)
+        return response_dict
 
     def _gettoken(self):
         # Get Oauth Token from tuyaPlatform
@@ -1996,7 +1996,7 @@ class Cloud(object):
                 )
 
         self.token = response_dict['result']['access_token']
-        return(self.token)
+        return self.token
 
     def _getuid(self, deviceid=None):
         # Get user ID (UID) for deviceid
@@ -2014,7 +2014,7 @@ class Cloud(object):
             )
             return None
         uid = response_dict['result']['uid']
-        return(uid)
+        return uid
 
     def getdevices(self, verbose=False):
         """
@@ -2033,7 +2033,7 @@ class Cloud(object):
         json_data = self._tuyaplatform(uri)
 
         if verbose:
-            return(json_data)
+            return json_data
         else:
             # Filter to only Name, ID and Key
             tuyadevices = []
@@ -2043,7 +2043,7 @@ class Cloud(object):
                 item['id'] = i['id']
                 item['key'] = i['local_key']
                 tuyadevices.append(item)
-            return(tuyadevices)
+            return tuyadevices
 
     def _getdevice(self, param='status', deviceid=None):
         if deviceid is None:
@@ -2058,25 +2058,25 @@ class Cloud(object):
             log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
-        return(response_dict)
+        return response_dict
 
     def getstatus(self, deviceid=None):
         """
         Get the status of the device.
         """
-        return(self._getdevice('status', deviceid))
+        return self._getdevice('status', deviceid)
 
     def getfunctions(self, deviceid=None):
         """
         Get the functions of the device.
         """
-        return(self._getdevice('functions', deviceid))
+        return self._getdevice('functions', deviceid)
 
     def getproperties(self, deviceid=None):
         """
         Get the properties of the device.
         """
-        return(self._getdevice('specification', deviceid))
+        return self._getdevice('specification', deviceid)
 
     def getdps(self, deviceid=None):
         """
@@ -2094,7 +2094,7 @@ class Cloud(object):
             log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
-        return(response_dict)
+        return response_dict
 
     def sendcommand(self, deviceid=None, commands=None):
         """
@@ -2112,4 +2112,4 @@ class Cloud(object):
             log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
-        return(response_dict)
+        return response_dict

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -64,7 +64,7 @@
         (r, g, b) = colour_rgb():
         (h,s,v) = colour_hsv()
         result = state():
-    
+
     Cloud
         setregion(apiRegion)
         getdevices(verbose=False)
@@ -121,7 +121,7 @@ __author__ = "jasonacox"
 
 log = logging.getLogger(__name__)
 # Uncomment the following to set debug mode or call set_debug()
-# logging.basicConfig(level=logging.DEBUG)  
+# logging.basicConfig(level=logging.DEBUG)
 
 log.debug("%s version %s", __name__, __version__)
 log.debug("Python %s on %s", sys.version, sys.platform)
@@ -1854,7 +1854,7 @@ class Cloud(object):
             * Get UserID = https://openapi.tuyaus.com/v1.0/devices/{DeviceID}
             * Get Devices = https://openapi.tuyaus.com/v1.0/users/{UserID}/devices
 
-        REFERENCE: 
+        REFERENCE:
             * https://images.tuyacn.com/smart/docs/python_iot_code_sample.py
             * https://iot.tuya.com/cloud/products/detail
         """
@@ -1876,8 +1876,8 @@ class Cloud(object):
                 with open(self.CONFIGFILE) as f:
                     config = json.load(f)
                     self.apiRegion = config['apiRegion']
-                    self.apiKey = config['apiKey'] 
-                    self.apiSecret = config['apiSecret'] 
+                    self.apiKey = config['apiKey']
+                    self.apiSecret = config['apiSecret']
                     self.apiDeviceID = config['apiDeviceID']
             except:
                 return error_json(
@@ -1888,7 +1888,7 @@ class Cloud(object):
         self.setregion(apiRegion)
         # Attempt to connect to cloud and get token
         self.token = self._gettoken()
-    
+
     def setregion(self, apiRegion=None):
         # Set hostname based on apiRegion
         if apiRegion is None:
@@ -1908,7 +1908,7 @@ class Cloud(object):
 
     def _tuyaplatform(self, uri, action='GET', post=None, ver='v1.0', recursive=False):
         """
-        Handle GET and POST requests to Tuya Cloud 
+        Handle GET and POST requests to Tuya Cloud
         """
         # Build URL and Header
         url = "https://%s/%s/%s" % (self.urlhost, ver, uri)
@@ -1926,15 +1926,15 @@ class Cloud(object):
             headers['secret'] = self.apiSecret
         else:
             payload = self.apiKey + self.token + str(now)
-        
+
         # If running the post 6-30-2021 signing algorithm update the payload to include it's data
-        if self.new_sign_algorithm: 
+        if self.new_sign_algorithm:
             payload += ('%s\n' % action +                                                # HTTPMethod
                 hashlib.sha256(bytes((body or "").encode('utf-8'))).hexdigest() + '\n' + # Content-SHA256
                 ''.join(['%s:%s\n'%(key, headers[key])                                   # Headers
                             for key in headers.get("Signature-Headers", "").split(":")
                             if key in headers]) + '\n' +
-                '/' + url.split('//', 1)[-1].split('/', 1)[-1])  
+                '/' + url.split('//', 1)[-1].split('/', 1)[-1])
         # Sign Payload
         signature = hmac.new(
             self.apiSecret.encode('utf-8'),
@@ -1947,7 +1947,7 @@ class Cloud(object):
         headers['sign'] = signature
         headers['t'] = str(now)
         headers['sign_method'] = 'HMAC-SHA256'
-        
+
         if(self.token != None):
             headers['access_token'] = self.token
 
@@ -1962,7 +1962,7 @@ class Cloud(object):
                 "POST: URL=%s HEADERS=%s DATA=%s" % (url, headers, body),
             )
             response = requests.post(url, headers=headers, data=body)
-        
+
         # Check to see if token is expired
         if "token invalid" in response.text:
             if recursive is True:
@@ -2020,11 +2020,11 @@ class Cloud(object):
             return None
         uid = response_dict['result']['uid']
         return(uid)
-        
+
     def getdevices(self, verbose=False):
         """
-        Return dictionary of all devices. 
-        If verbose is true, return full Tuya device 
+        Return dictionary of all devices.
+        If verbose is true, return full Tuya device
         details.
         """
         uid = self._getuid(self.apiDeviceID)
@@ -2064,28 +2064,28 @@ class Cloud(object):
                     "Error from Tuya Cloud: %r" % response_dict['msg'],
             )
         return(response_dict)
-    
+
     def getstatus(self, deviceid=None):
         """
-        Get the status of the device. 
+        Get the status of the device.
         """
         return(self._getdevice('status', deviceid))
 
     def getfunctions(self, deviceid=None):
         """
-        Get the functions of the device. 
+        Get the functions of the device.
         """
         return(self._getdevice('functions', deviceid))
 
     def getproperties(self, deviceid=None):
         """
-        Get the properties of the device. 
+        Get the properties of the device.
         """
         return(self._getdevice('specification', deviceid))
 
     def getdps(self, deviceid=None):
         """
-        Get the specifications including DPS IDs of the device. 
+        Get the specifications including DPS IDs of the device.
         """
         if deviceid is None:
             return error_json(

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -1916,7 +1916,7 @@ class Cloud(object):
             action = 'GET'
         now = int(time.time()*1000)
         headers = dict(list(headers.items()) + [('Signature-Headers', ":".join(headers.keys()))]) if headers else {}
-        if self.token==None:
+        if self.token is None:
             payload = self.apiKey + str(now)
             headers['secret'] = self.apiSecret
         else:
@@ -1943,7 +1943,7 @@ class Cloud(object):
         headers['t'] = str(now)
         headers['sign_method'] = 'HMAC-SHA256'
 
-        if self.token != None:
+        if self.token is not None:
             headers['access_token'] = self.token
 
         # Send Request to Cloud and Get Response

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -86,20 +86,21 @@
 
 # Modules
 from __future__ import print_function  # python 2.7 support
+import binascii
+from collections import namedtuple
+import colorsys
 import base64
+import hashlib
 from hashlib import md5
+import hmac
 import json
 import logging
 import socket
+import struct
 import sys
 import time
-import colorsys
-import binascii
-import struct
+
 import requests
-import hmac
-import hashlib
-from collections import namedtuple
 
 # Backward compatability for python2
 try:

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -1013,13 +1013,16 @@ class Device(XenonDevice):
         log.debug("heartbeat received data=%r", data)
         return data
 
-    def updatedps(self, index=[1]):
+    def updatedps(self, index=None):
         """
         Request device to update index.
 
         Args:
             index(array): list of dps to update (ex. [4, 5, 6, 18, 19, 20])
         """
+        if index is None:
+            index = [1]
+
         log.debug("updatedps() entry (dev_type is %s)", self.dev_type)
         # open device, send request, then close connection
         payload = self.generate_payload(UPDATEDPS, index)

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -1990,10 +1990,10 @@ class Cloud(object):
         response_dict = self._tuyaplatform('token?grant_type=1')
 
         if not response_dict['success']:
-                return error_json(
-                    ERR_CLOUDTOKEN,
-                    "Cloud _gettoken() failed: %r" % response_dict['msg'],
-                )
+            return error_json(
+                ERR_CLOUDTOKEN,
+                "Cloud _gettoken() failed: %r" % response_dict['msg'],
+            )
 
         self.token = response_dict['result']['access_token']
         return self.token

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -324,7 +324,7 @@ def set_debug(toggle=True, color=True):
         else:
             logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
         log.setLevel(logging.DEBUG)
-        log.debug("TinyTuya [%s]\n" % __version__)
+        log.debug("TinyTuya [%s]\n", __version__)
     else:
         log.setLevel(logging.NOTSET)
 
@@ -375,7 +375,7 @@ def error_json(number=None, payload=None):
         spayload = '""'
 
     vals = (error_codes[number], str(number), spayload)
-    log.debug("ERROR %s - %s - payload: %s" % vals)
+    log.debug("ERROR %s - %s - payload: %s", *vals)
 
     return json.loads('{ "Error":"%s", "Err":"%s", "Payload":%s }' % vals)
 
@@ -518,16 +518,16 @@ class XenonDevice(object):
                 except socket.timeout as err:
                     # unable to open socket
                     log.debug(
-                        "socket unable to connect - retry %d/%d"
-                        % (retries, self.socketRetryLimit)
+                        "socket unable to connect - retry %d/%d",
+                        retries, self.socketRetryLimit
                     )
                     self.socket.close()
                     time.sleep(0.1)
                 except Exception as err:
                     # unable to open socket
                     log.debug(
-                        "socket unable to connect - retry %d/%d"
-                        % (retries, self.socketRetryLimit)
+                        "socket unable to connect - retry %d/%d",
+                        retries, self.socketRetryLimit
                     )
                     self.socket.close()
                     time.sleep(5)
@@ -586,10 +586,8 @@ class XenonDevice(object):
                     return None
                 retries = retries + 1
                 log.debug(
-                    "Timeout or exception in _send_receive() - retry "
-                    + str(retries)
-                    + "/"
-                    + str(self.socketRetryLimit)
+                    "Timeout or exception in _send_receive() - retry %s / %s",
+                    retries, self.socketRetryLimit
                 )
                 # if we exceed the limit of retries then lets get out of here
                 if retries > self.socketRetryLimit:
@@ -597,9 +595,8 @@ class XenonDevice(object):
                         self.socket.close()
                         self.socket = None
                     log.debug(
-                        "Exceeded tinytuya retry limit ("
-                        + str(self.socketRetryLimit)
-                        + ")"
+                        "Exceeded tinytuya retry limit (%s)",
+                        self.socketRetryLimit
                     )
                     # timeout reached - return error
                     json_payload = error_json(
@@ -613,10 +610,8 @@ class XenonDevice(object):
                 # likely network or connection error
                 retries = retries + 1
                 log.debug(
-                    "Network connection error - retry "
-                    + str(retries)
-                    + "/"
-                    + str(self.socketRetryLimit)
+                    "Network connection error - retry %s/%s",
+                    retries, self.socketRetryLimit
                 )
                 # if we exceed the limit of retries then lets get out of here
                 if retries > self.socketRetryLimit:
@@ -624,9 +619,8 @@ class XenonDevice(object):
                         self.socket.close()
                         self.socket = None
                     log.debug(
-                        "Exceeded tinytuya retry limit ("
-                        + str(self.socketRetryLimit)
-                        + ")"
+                        "Exceeded tinytuya retry limit (%s)",
+                        self.socketRetryLimit
                     )
                     log.debug("Unable to connect to device ")
                     # timeout reached - return error
@@ -690,7 +684,7 @@ class XenonDevice(object):
 
             log.debug("decrypted 3.3 payload=%r", payload)
             # Try to detect if device22 found
-            log.debug("payload type = %s" % type(payload))
+            log.debug("payload type = %s", type(payload))
             if not isinstance(payload, str):
                 try:
                     payload = payload.decode()
@@ -809,7 +803,7 @@ class XenonDevice(object):
         """
         if did is None:
             return (None, None)
-        log.debug("Listening for device %s on the network" % did)
+        log.debug("Listening for device %s on the network", did)
         # Enable UDP listening broadcasting mode on UDP port 6666 - 3.1 Devices
         client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         client.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
@@ -1347,7 +1341,7 @@ class BulbDevice(Device):
         else:
             # response has no dps
             self.bulb_type = "B"
-        log.debug("bulb type set to %s" % self.bulb_type)
+        log.debug("bulb type set to %s", self.bulb_type)
 
     def turn_on(self, switch=0):
         """Turn the device on"""
@@ -1956,11 +1950,11 @@ class Cloud(object):
         if action == 'GET':
             response = requests.get(url, headers=headers)
             log.debug(
-                "GET: response code=%d text=%s token=%s" % (response.status_code, response.text, self.token)
+                "GET: response code=%d text=%s token=%s", response.status_code, response.text, self.token
             )
         else:
             log.debug(
-                "POST: URL=%s HEADERS=%s DATA=%s" % (url, headers, body),
+                "POST: URL=%s HEADERS=%s DATA=%s", url, headers, body,
             )
             response = requests.post(url, headers=headers, data=body)
 
@@ -2016,7 +2010,7 @@ class Cloud(object):
 
         if not response_dict['success']:
             log.debug(
-                    "Error from Tuya Cloud: %r" % response_dict['msg'],
+                "Error from Tuya Cloud: %r", response_dict['msg'],
             )
             return None
         uid = response_dict['result']['uid']
@@ -2062,7 +2056,7 @@ class Cloud(object):
 
         if not response_dict['success']:
             log.debug(
-                    "Error from Tuya Cloud: %r" % response_dict['msg'],
+                "Error from Tuya Cloud: %r", response_dict['msg'],
             )
         return(response_dict)
 
@@ -2098,7 +2092,7 @@ class Cloud(object):
 
         if not response_dict['success']:
             log.debug(
-                    "Error from Tuya Cloud: %r" % response_dict['msg'],
+                "Error from Tuya Cloud: %r", response_dict['msg'],
             )
         return(response_dict)
 
@@ -2116,6 +2110,6 @@ class Cloud(object):
 
         if not response_dict['success']:
             log.debug(
-                    "Error from Tuya Cloud: %r" % response_dict['msg'],
+                "Error from Tuya Cloud: %r", response_dict['msg'],
             )
         return(response_dict)

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -8,7 +8,7 @@
 
  Run TinyTuya Setup Wizard:
     python -m tinytuya wizard
- This network scan will run if calling this module via command line:  
+ This network scan will run if calling this module via command line:
     python -m tinytuya <max_retry>
 
 """

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -26,21 +26,21 @@ retriesprovided = False
 force = False
 
 for i in sys.argv:
-    if(i==sys.argv[0]):
+    if i==sys.argv[0]:
         continue
-    if(i.lower() == "wizard"):
+    if i.lower() == "wizard":
         state = 1
-    elif(i.lower() == "scan"):
+    elif i.lower() == "scan":
         state = 0
-    elif(i.lower() == "-nocolor"):
+    elif i.lower() == "-nocolor":
         color = False
-    elif(i.lower() == "-force"):
+    elif i.lower() == "-force":
         force = True
-    elif(i.lower() == "snapshot"):
+    elif i.lower() == "snapshot":
         state = 2
-    elif(i.lower() == "devices"):
+    elif i.lower() == "devices":
         state = 3
-    elif(i.lower() == "json"):
+    elif i.lower() == "json":
         state = 4
     else:
         try:
@@ -50,36 +50,36 @@ for i in sys.argv:
             state = 10
 
 # State 0 = Run Network Scan
-if(state == 0):
-    if(retriesprovided):
+if state == 0:
+    if retriesprovided:
         scanner.scan(maxretry=retries, color=color, forcescan=force)
     else:
         scanner.scan(color=color, forcescan=force)
 
 # State 1 = Run Setup Wizard
-if(state == 1):
-    if(retriesprovided):
+if state == 1:
+    if retriesprovided:
         wizard.wizard(color=color, retries=retries, forcescan=force)
     else:
         wizard.wizard(color=color, forcescan=force)
 
 # State 2 = Snapshot Display and Scan
-if(state == 2):
+if state == 2:
     scanner.snapshot(color=color)
 
 # State 3 = Scan All Devices
-if(state == 3):
-    if(retriesprovided):
+if state == 3:
+    if retriesprovided:
         scanner.alldevices(color=color, retries=retries)
     else:
         scanner.alldevices(color=color)
 
 # State 4 = Scan All Devices
-if(state == 4):
+if state == 4:
     scanner.snapshotjson()
 
 # State 10 = Show Usage
-if(state == 10):
+if state == 10:
     print("TinyTuya [%s]\n" % (tinytuya.version))
     print("Usage:\n")
     print("    python -m tinytuya [command] [<max_retry>] [-nocolor] [-h]")

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -14,8 +14,8 @@
 """
 
 # Modules
-import tinytuya
 import sys
+import tinytuya
 from . import wizard
 from . import scanner
 

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -483,7 +483,7 @@ def snapshot(color=True):
     # Find out if we should poll all devices
     answer = input(subbold + '\nPoll local devices? ' +
                    normal + '(Y/n): ')
-    if(answer[0:1].lower() != 'n'):
+    if answer[0:1].lower() != 'n':
         print("")
         print("%sPolling %s local devices from last snapshot..." % (normal, len(devices)))
         for i in devices:
@@ -499,7 +499,7 @@ def snapshot(color=True):
             item['ver'] = ver
             item['id'] = i['id']
             item['key'] = i['key']
-            if (ip == 0):
+            if ip == 0:
                 print("    %s[%s] - %s%s - %sError: No IP found%s" %
                       (subbold, name, dim, ip, alert, normal))
             else:
@@ -576,9 +576,9 @@ def alldevices(color=True, retries=None):
     # Find out if we should poll all devices
     answer = input(subbold + '\nPoll local devices? ' +
                    normal + '(Y/n): ')
-    if(answer[0:1].lower() != 'n'):
+    if answer[0:1].lower() != 'n':
         # Set retries based on number of devices if undefined
-        if(retries == None):
+        if retries == None:
             retries = len(tuyadevices)+10+tinytuya.MAXCOUNT
 
         # Scan network for devices and provide polling data
@@ -591,7 +591,7 @@ def alldevices(color=True, retries=None):
         def getIP(d, gwid):
             for ip in d:
                 if 'gwId' in d[ip]:
-                    if (gwid == d[ip]['gwId']):
+                    if gwid == d[ip]['gwId']:
                         return (ip, d[ip]['version'])
             return (0, 0)
 
@@ -609,7 +609,7 @@ def alldevices(color=True, retries=None):
             item['key'] = i['key']
             if "mac" in i:
                 item['mac'] = i['mac']
-            if (ip == 0):
+            if ip == 0:
                 print("    %s[%s] - %s%s - %sError: No IP found%s" %
                       (subbold, name, dim, ip, alert, normal))
             else:
@@ -689,7 +689,7 @@ def snapshotjson():
         item['key'] = i['key']
         if "mac" in i:
             item['mac'] = i['mac']
-        if (ip == 0):
+        if ip == 0:
             item['error'] = "No IP"
         else:
             try:

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -14,15 +14,14 @@ Description
 """
 # Modules
 from __future__ import print_function
-from audioop import add  # python 2.7 support
-import logging
-import time
-import json
-import tinytuya
-from hashlib import md5
-import socket
 import ipaddress
+import json
+import logging
+import socket
 import sys
+import time
+
+import tinytuya
 
 try:
     # Optional libraries required for forced scanning

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -514,11 +514,11 @@ def snapshot(color=True):
                         try:
                             if '1' in data['dps'] or '20' in data['dps']:
                                 if '1' in data['dps']:
-                                        if data['dps']['1'] == True:
-                                            state = bold + "On" + dim
+                                    if data['dps']['1'] == True:
+                                        state = bold + "On" + dim
                                 if '20' in data['dps']:
-                                        if data['dps']['20'] == True:
-                                            state = bold + "On" + dim
+                                    if data['dps']['20'] == True:
+                                        state = bold + "On" + dim
                                 print("    %s[%s] - %s%s - %s - DPS: %r" %
                                     (subbold, name, dim, ip, state, data['dps']))
                             else:
@@ -624,11 +624,11 @@ def alldevices(color=True, retries=None):
                         try:
                             if '1' in data['dps'] or '20' in data['dps']:
                                 if '1' in data['dps']:
-                                        if data['dps']['1'] == True:
-                                            state = bold + "On" + dim
+                                    if data['dps']['1'] == True:
+                                        state = bold + "On" + dim
                                 if '20' in data['dps']:
-                                        if data['dps']['20'] == True:
-                                            state = bold + "On" + dim
+                                    if data['dps']['20'] == True:
+                                        state = bold + "On" + dim
                                 print("    %s[%s] - %s%s - %s - DPS: %r" %
                                     (subbold, name, dim, ip, state, data['dps']))
                             else:

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -126,7 +126,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
         with open(DEVICEFILE) as f:
             tuyadevices = json.load(f)
             havekeys = True
-            log.debug("loaded=%s [%d devices]" % (DEVICEFILE, len(tuyadevices)))
+            log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
             # If no maxretry value set, base it on number of devices
             if maxretry is None:
                 maxretry = len(tuyadevices) + tinytuya.MAXCOUNT
@@ -214,7 +214,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
                     ip = "%s" % addr
                     mac = get_mac_address(ip=ip)
                     ip_list[ip] = mac
-                    log.debug("Found Device [%s]" % mac)
+                    log.debug("Found Device [%s]", mac)
                     if verbose:
                         print(" Found Device [%s]" % mac)
                 a_socket.close()
@@ -273,7 +273,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
                 result = result.decode()
 
             result = json.loads(result)
-            log.debug("Received valid UDP packet: %r" % result)
+            log.debug("Received valid UDP packet: %r", result)
 
             note = "Valid"
             ip = result["ip"]
@@ -285,7 +285,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
                 print(alertdim + "*  Unexpected payload=%r\n" + normal, result)
             result = {"ip": ip}
             note = "Unknown"
-            log.debug("Invalid UDP Packet: %r" % result)
+            log.debug("Invalid UDP Packet: %r", result)
 
         # check to see if we have seen this device before and add to devices array
         if tinytuya.appenddevice(result, devices) is False:
@@ -428,7 +428,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
         with open(SNAPSHOTFILE, "w") as outfile:
             outfile.write(output)
 
-    log.debug("Scan complete with %s devices found" % len(devices))
+    log.debug("Scan complete with %s devices found", len(devices))
     clients.close()
     client.close()
     if byID:
@@ -558,7 +558,7 @@ def alldevices(color=True, retries=None):
         # Load defaults
         with open(DEVICEFILE) as f:
             tuyadevices = json.load(f)
-            log.debug("loaded=%s [%d devices]" % (DEVICEFILE, len(tuyadevices)))
+            log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
             # If no maxretry value set, base it on number of devices
             if retries is None:
                 retries = len(tuyadevices) + tinytuya.MAXCOUNT

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -8,7 +8,7 @@ For more information see https://github.com/jasonacox/tinytuya
 
 Description
     Scan will scan the local network for Tuya devices and if a local devices.json is
-    present in the local directory, will use the Local KEYs to poll the devices for 
+    present in the local directory, will use the Local KEYs to poll the devices for
     status.
 
 """
@@ -21,7 +21,7 @@ import json
 import tinytuya
 from hashlib import md5
 import socket
-import ipaddress  
+import ipaddress
 import sys
 
 try:
@@ -57,7 +57,7 @@ TCPPORT = tinytuya.TCPPORT          # Tuya TCP Local Port
 MAXCOUNT = tinytuya.MAXCOUNT        # How many tries before stopping
 UDPPORT = tinytuya.UDPPORT          # Tuya 3.1 UDP Port
 UDPPORTS = tinytuya.UDPPORTS        # Tuya 3.3 encrypted UDP Port
-TIMEOUT = tinytuya.TIMEOUT          # Socket Timeout 
+TIMEOUT = tinytuya.TIMEOUT          # Socket Timeout
 
 # Logging
 log = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ def getmyIP():
     r = s.getsockname()[0]
     s.close()
     return r
-    
+
 
 # Scan function shortcut
 def scan(maxretry=None, color=True, forcescan=False):
@@ -165,8 +165,8 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
     if forcescan:
         if not SCANLIBS:
             if verbose:
-                print(alert + 
-                    '    ERROR: force network scanning requested but not available - disabled.\n' 
+                print(alert +
+                    '    ERROR: force network scanning requested but not available - disabled.\n'
                     '           (Requires: pip install getmac)\n' + dim)
             forcescan = False
         else:
@@ -182,7 +182,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
 
     if forcescan:
         # Force Scan - Get list of all local ip addresses
-        try: 
+        try:
             # Fetch my IP address and assume /24 network
             ip = getmyIP()
             network = ipaddress.IPv4Interface(u''+ip+'/24').network
@@ -192,10 +192,10 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
             ip = None
             log.debug("Unable to get local network, using default %r", network)
             if verbose:
-                print(alert + 
-                    'ERROR: Unable to get your IP address and network automatically.' 
+                print(alert +
+                    'ERROR: Unable to get your IP address and network automatically.'
                     '       (using %s)' % network + normal)
-        
+
         try:
             # Warn user of scan duration
             if verbose:
@@ -219,9 +219,9 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
                     if verbose:
                         print(" Found Device [%s]" % mac)
                 a_socket.close()
-            
+
             if verbose:
-                print(dim + '\r      Done                           ' +normal + 
+                print(dim + '\r      Done                           ' +normal +
                             '\n\nDiscovered %d Tuya Devices\n' % len(ip_list))
 
         except:
@@ -424,7 +424,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
                 tmp["ip"] = 0
                 devicesarray.append(tmp)
         current = {'timestamp' : time.time(), 'devices' : devicesarray}
-        output = json.dumps(current, indent=4) 
+        output = json.dumps(current, indent=4)
         print(bold + "\n>> " + normal + "Saving device snapshot data to " + SNAPSHOTFILE + "\n")
         with open(SNAPSHOTFILE, "w") as outfile:
             outfile.write(output)
@@ -467,7 +467,7 @@ def snapshot(color=True):
     print("%s%-25s %-24s %-16s %-17s %-5s" % (normal, "Name","ID", "IP","Key","Version"))
     print(dim)
     for id in sorted(data["devices"], key=lambda x: x['name']):
-        device = id 
+        device = id
         ver = ip = ""
         if "ver"  in device:
             ver = device["ver"]
@@ -476,7 +476,7 @@ def snapshot(color=True):
         name = device["name"]
         gwId = device["id"]
         key = device["key"]
-        print("%s%-25.25s %s%-24s %s%-16s %s%-17s %s%-5s" % 
+        print("%s%-25.25s %s%-24s %s%-16s %s%-17s %s%-5s" %
             (dim, name, cyan, gwId, subbold, ip, red, key, yellow, ver))
 
     devices = sorted(data["devices"], key=lambda x: x['name'])
@@ -568,10 +568,10 @@ def alldevices(color=True, retries=None):
         return
 
     print("%sLoaded %s - %d devices:" % (dim, DEVICEFILE, len(tuyadevices)))
-    
+
     # Display device list
     print("\n\n" + bold + "Device Listing\n" + dim)
-    output = json.dumps(sorted(tuyadevices,key=lambda x: x['name']), indent=4) 
+    output = json.dumps(sorted(tuyadevices,key=lambda x: x['name']), indent=4)
     print(output)
 
     # Find out if we should poll all devices
@@ -649,7 +649,7 @@ def alldevices(color=True, retries=None):
 
         # Save polling data snapsot
         current = {'timestamp' : time.time(), 'devices' : polling}
-        output = json.dumps(current, indent=4) 
+        output = json.dumps(current, indent=4)
         print(bold + "\n>> " + normal + "Saving device snapshot data to " + SNAPSHOTFILE)
         with open(SNAPSHOTFILE, "w") as outfile:
             outfile.write(output)
@@ -669,7 +669,7 @@ def snapshotjson():
             data = json.load(json_file)
     except:
         current = {'timestamp' : time.time(), 'error' : 'Missing %s' % SNAPSHOTFILE}
-        output = json.dumps(current, indent=4) 
+        output = json.dumps(current, indent=4)
         print(output)
         return
 
@@ -707,7 +707,7 @@ def snapshotjson():
         polling.append(item)
     # for loop
     current = {'timestamp' : time.time(), 'devices' : polling}
-    output = json.dumps(current, indent=4) 
+    output = json.dumps(current, indent=4)
     print(output)
     return
 

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -417,7 +417,7 @@ def devices(verbose=False, maxretry=None, color=True, poll=True, forcescan=False
         for item in devices:
             devicesarray.append(devices[item])
         for item in tuyadevices:
-            if next((x for x in devicesarray if x["id"] == item["id"]), False) == False:
+            if next((x for x in devicesarray if x["id"] == item["id"]), False) is False:
                 tmp = item
                 tmp["gwId"] = item["id"]
                 tmp["ip"] = 0
@@ -514,10 +514,10 @@ def snapshot(color=True):
                         try:
                             if '1' in data['dps'] or '20' in data['dps']:
                                 if '1' in data['dps']:
-                                    if data['dps']['1'] == True:
+                                    if data['dps']['1'] is True:
                                         state = bold + "On" + dim
                                 if '20' in data['dps']:
-                                    if data['dps']['20'] == True:
+                                    if data['dps']['20'] is True:
                                         state = bold + "On" + dim
                                 print("    %s[%s] - %s%s - %s - DPS: %r" %
                                     (subbold, name, dim, ip, state, data['dps']))
@@ -578,7 +578,7 @@ def alldevices(color=True, retries=None):
                    normal + '(Y/n): ')
     if answer[0:1].lower() != 'n':
         # Set retries based on number of devices if undefined
-        if retries == None:
+        if retries is None:
             retries = len(tuyadevices)+10+tinytuya.MAXCOUNT
 
         # Scan network for devices and provide polling data
@@ -624,10 +624,10 @@ def alldevices(color=True, retries=None):
                         try:
                             if '1' in data['dps'] or '20' in data['dps']:
                                 if '1' in data['dps']:
-                                    if data['dps']['1'] == True:
+                                    if data['dps']['1'] is True:
                                         state = bold + "On" + dim
                                 if '20' in data['dps']:
-                                    if data['dps']['20'] == True:
+                                    if data['dps']['20'] is True:
                                         state = bold + "On" + dim
                                 print("    %s[%s] - %s%s - %s - DPS: %r" %
                                     (subbold, name, dim, ip, state, data['dps']))

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -404,11 +404,11 @@ def wizard(color=True, retries=None, forcescan=False):
                         try:
                             if '1' in data['dps'] or '20' in data['dps']:
                                 if '1' in data['dps']:
-                                        if data['dps']['1'] == True:
-                                            state = bold + "On" + dim
+                                    if data['dps']['1'] == True:
+                                        state = bold + "On" + dim
                                 if '20' in data['dps']:
-                                        if data['dps']['20'] == True:
-                                            state = bold + "On" + dim
+                                    if data['dps']['20'] == True:
+                                        state = bold + "On" + dim
                                 print("    %s[%s] - %s%s - %s - DPS: %r" %
                                     (subbold, name, dim, ip, state, data['dps']))
                             else:

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -116,7 +116,7 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
     # Build Header
     now = int(time.time()*1000)
     headers = dict(list(headers.items()) + [('Signature-Headers', ":".join(headers.keys()))]) if headers else {}
-    if token==None:
+    if token is None:
         payload = apiKey + str(now)
         headers['secret'] = apiSecret
     else:
@@ -142,7 +142,7 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
     headers['t'] = str(now)
     headers['sign_method'] = 'HMAC-SHA256'
 
-    if token != None:
+    if token is not None:
         headers['access_token'] = token
 
     # Get Token
@@ -361,7 +361,7 @@ def wizard(color=True, retries=None, forcescan=False):
                    normal + '(Y/n): ')
     if answer[0:1].lower() != 'n':
         # Set retries based on number of devices if undefined
-        if retries == None:
+        if retries is None:
             retries = len(tuyadevices)+10+tinytuya.MAXCOUNT
 
         # Scan network for devices and provide polling data
@@ -404,10 +404,10 @@ def wizard(color=True, retries=None, forcescan=False):
                         try:
                             if '1' in data['dps'] or '20' in data['dps']:
                                 if '1' in data['dps']:
-                                    if data['dps']['1'] == True:
+                                    if data['dps']['1'] is True:
                                         state = bold + "On" + dim
                                 if '20' in data['dps']:
-                                    if data['dps']['20'] == True:
+                                    if data['dps']['20'] is True:
                                         state = bold + "On" + dim
                                 print("    %s[%s] - %s%s - %s - DPS: %r" %
                                     (subbold, name, dim, ip, state, data['dps']))

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -123,12 +123,13 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
         payload = apiKey + token + str(now)
 
     # If running the post 6-30-2021 signing algorithm update the payload to include it's data
-    if new_sign_algorithm: payload += ('GET\n' +                                                                # HTTPMethod
-                                       hashlib.sha256(bytes((body or "").encode('utf-8'))).hexdigest() + '\n' + # Content-SHA256
-                                       ''.join(['%s:%s\n'%(key, headers[key])                                   # Headers
-                                                for key in headers.get("Signature-Headers", "").split(":")
-                                                if key in headers]) + '\n' +
-                                       '/' + url.split('//', 1)[-1].split('/', 1)[-1])
+    if new_sign_algorithm:
+        payload += ('GET\n' +                                                                # HTTPMethod
+                    hashlib.sha256(bytes((body or "").encode('utf-8'))).hexdigest() + '\n' + # Content-SHA256
+                    ''.join(['%s:%s\n'%(key, headers[key])                                   # Headers
+                             for key in headers.get("Signature-Headers", "").split(":")
+                             if key in headers]) + '\n' +
+                    '/' + url.split('//', 1)[-1].split('/', 1)[-1])
     # Sign Payload
     signature = hmac.new(
         apiSecret.encode('utf-8'),

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -7,9 +7,9 @@ Author: Jason A. Cox
 For more information see https://github.com/jasonacox/tinytuya
 
 Description
-    Setup Wizard will prompt the user for Tuya IoT Developer credentials and will gather all 
+    Setup Wizard will prompt the user for Tuya IoT Developer credentials and will gather all
     registered Device IDs and their Local KEYs.  It will save the credentials and the device
-    data in the tinytuya.json and devices.json configuration files respectively. The Wizard 
+    data in the tinytuya.json and devices.json configuration files respectively. The Wizard
     will then optionally scan the local devices for status.
 
     HOW to set up your Tuya IoT Developer account: iot.tuya.com:
@@ -69,7 +69,7 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
     Parameters:
         * region     Tuya API Server Region: us, eu, cn, in, us-e, eu-w
         * apiKey     Tuya Platform Developer ID
-        * apiSecret  Tuya Platform Developer secret 
+        * apiSecret  Tuya Platform Developer secret
         * uri        Tuya Platform URI for this call
         * token      Tuya OAuth Token
 
@@ -120,14 +120,14 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
         headers['secret'] = apiSecret
     else:
         payload = apiKey + token + str(now)
-    
+
     # If running the post 6-30-2021 signing algorithm update the payload to include it's data
     if new_sign_algorithm: payload += ('GET\n' +                                                                # HTTPMethod
                                        hashlib.sha256(bytes((body or "").encode('utf-8'))).hexdigest() + '\n' + # Content-SHA256
                                        ''.join(['%s:%s\n'%(key, headers[key])                                   # Headers
                                                 for key in headers.get("Signature-Headers", "").split(":")
                                                 if key in headers]) + '\n' +
-                                       '/' + url.split('//', 1)[-1].split('/', 1)[-1])  
+                                       '/' + url.split('//', 1)[-1].split('/', 1)[-1])
     # Sign Payload
     signature = hmac.new(
         apiSecret.encode('utf-8'),
@@ -140,7 +140,7 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
     headers['sign'] = signature
     headers['t'] = str(now)
     headers['sign_method'] = 'HMAC-SHA256'
-    
+
     if(token != None):
         headers['access_token'] = token
 
@@ -194,7 +194,7 @@ def wizard(color=True, retries=None, forcescan=False):
     except:
         # First Time Setup
         pass
-    
+
     (bold, subbold, normal, dim, alert, alertdim, cyan, red, yellow) = tinytuya.termcolor(color)
 
     print(bold + 'TinyTuya Setup Wizard' + dim + ' [%s]' % (tinytuya.version) + normal)
@@ -202,8 +202,8 @@ def wizard(color=True, retries=None, forcescan=False):
 
     if forcescan:
         if not SCANLIBS:
-            print(alert + 
-                '    ERROR: force network scanning requested but not available - disabled.\n' 
+            print(alert +
+                '    ERROR: force network scanning requested but not available - disabled.\n'
                 '           (Requires: pip install getmac)\n' + dim)
             forcescan = False
         else:
@@ -264,7 +264,7 @@ def wizard(color=True, retries=None, forcescan=False):
 
     token = response_dict['result']['access_token']
 
-    # Get UID from sample Device ID 
+    # Get UID from sample Device ID
     uri = 'devices/%s' % DEVICEID
     response_dict = tuyaPlatform(REGION, KEY, SECRET, uri, token)
 
@@ -284,17 +284,17 @@ def wizard(color=True, retries=None, forcescan=False):
 
     if forcescan:
         # Force Scan - Get list of all local ip addresses
-        try: 
+        try:
             # Fetch my IP address and assume /24 network
             ip = getmyIP()
             network = ipaddress.IPv4Interface(u''+ip+'/24').network
         except:
             network = DEFAULT_NETWORK
             ip = None
-            print(alert + 
-                'ERROR: Unable to get your IP address and network automatically.\n' 
+            print(alert +
+                'ERROR: Unable to get your IP address and network automatically.\n'
                 '       (using %s)' % network + normal)
-        
+
         try:
             # Warn user of scan duration
             print("\n" + bold + "Scanning local network.  This may take a while..." + dim)
@@ -314,8 +314,8 @@ def wizard(color=True, retries=None, forcescan=False):
                     ip_list[ip] = mac
                     print(" Found Device [%s]" % mac)
                 a_socket.close()
-            
-            print(dim + '\r      Done                           ' +normal + 
+
+            print(dim + '\r      Done                           ' +normal +
                         '\n\nDiscovered %d Tuya Devices\n' % len(ip_list))
         except:
             print('\n' + alert + '    Error scanning network - Ignoring' + dim)
@@ -353,7 +353,7 @@ def wizard(color=True, retries=None, forcescan=False):
         with open(RAWFILE, "w") as outfile:
             outfile.write(json.dumps(json_data, indent=4))
     except:
-        print('\n\n' + bold + 'Unable to save raw file' + dim )  
+        print('\n\n' + bold + 'Unable to save raw file' + dim )
 
     # Find out if we should poll all devices
     answer = input(subbold + '\nPoll local devices? ' +
@@ -427,7 +427,7 @@ def wizard(color=True, retries=None, forcescan=False):
 
         # Save polling data snapsot
         current = {'timestamp' : time.time(), 'devices' : polling}
-        output = json.dumps(current, indent=4) 
+        output = json.dumps(current, indent=4)
         print(bold + "\n>> " + normal + "Saving device snapshot data to " + SNAPSHOTFILE)
         with open(SNAPSHOTFILE, "w") as outfile:
             outfile.write(output)

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -23,14 +23,15 @@ Credits
 """
 # Modules
 from __future__ import print_function
-import requests
-import time
 import hmac
 import hashlib
-import json
-import tinytuya
-import socket
 import ipaddress
+import json
+import socket
+import time
+
+import tinytuya
+
 try:
     from getmac import get_mac_address
     SCANLIBS = True

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -99,15 +99,15 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
     # Set hostname based on apiRegion
     apiRegion = apiRegion.lower()
     urlhost = "openapi.tuyacn.com"          # China Data Center
-    if(apiRegion == "us"):
+    if apiRegion == "us":
         urlhost = "openapi.tuyaus.com"      # Western America Data Center
-    if(apiRegion == "us-e"):
+    if apiRegion == "us-e":
         urlhost = "openapi-ueaz.tuyaus.com" # Eastern America Data Center
-    if(apiRegion == "eu"):
+    if apiRegion == "eu":
         urlhost = "openapi.tuyaeu.com"      # Central Europe Data Center
-    if(apiRegion == "eu-w"):
+    if apiRegion == "eu-w":
         urlhost = "openapi-weaz.tuyaeu.com" # Western Europe Data Center
-    if(apiRegion == "in"):
+    if apiRegion == "in":
         urlhost = "openapi.tuyain.com"      # India Datacenter
 
     # Build URL
@@ -116,7 +116,7 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
     # Build Header
     now = int(time.time()*1000)
     headers = dict(list(headers.items()) + [('Signature-Headers', ":".join(headers.keys()))]) if headers else {}
-    if(token==None):
+    if token==None:
         payload = apiKey + str(now)
         headers['secret'] = apiSecret
     else:
@@ -142,7 +142,7 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
     headers['t'] = str(now)
     headers['sign_method'] = 'HMAC-SHA256'
 
-    if(token != None):
+    if token != None:
         headers['access_token'] = token
 
     # Get Token
@@ -155,7 +155,7 @@ def tuyaPlatform(apiRegion, apiKey, apiSecret, uri, token=None, new_sign_algorit
         except:
             print("Failed to get valid JSON response")
 
-    return(response_dict)
+    return response_dict
 
 def wizard(color=True, retries=None, forcescan=False):
     """
@@ -210,7 +210,7 @@ def wizard(color=True, retries=None, forcescan=False):
         else:
             print(subbold + "    Option: " + dim + "Network force scanning requested.\n")
 
-    if(config['apiKey'] != '' and config['apiSecret'] != '' and
+    if (config['apiKey'] != '' and config['apiSecret'] != '' and
             config['apiRegion'] != '' and config['apiDeviceID'] != ''):
         needconfigs = False
         print("    " + subbold + "Existing settings:" + dim +
@@ -220,10 +220,10 @@ def wizard(color=True, retries=None, forcescan=False):
         print('')
         answer = input(subbold + '    Use existing credentials ' +
                        normal + '(Y/n): ')
-        if(answer[0:1].lower() == 'n'):
+        if answer[0:1].lower() == 'n':
             needconfigs = True
 
-    if(needconfigs):
+    if needconfigs:
         # Ask user for config settings
         print('')
         config['apiKey'] = input(subbold + "    Enter " + bold + "API Key" + subbold +
@@ -359,9 +359,9 @@ def wizard(color=True, retries=None, forcescan=False):
     # Find out if we should poll all devices
     answer = input(subbold + '\nPoll local devices? ' +
                    normal + '(Y/n): ')
-    if(answer[0:1].lower() != 'n'):
+    if answer[0:1].lower() != 'n':
         # Set retries based on number of devices if undefined
-        if(retries == None):
+        if retries == None:
             retries = len(tuyadevices)+10+tinytuya.MAXCOUNT
 
         # Scan network for devices and provide polling data
@@ -374,7 +374,7 @@ def wizard(color=True, retries=None, forcescan=False):
         def getIP(d, gwid):
             for ip in d:
                 if 'gwId' in d[ip]:
-                    if (gwid == d[ip]['gwId']):
+                    if gwid == d[ip]['gwId']:
                         return (ip, d[ip]['version'])
             return (0, 0)
 
@@ -389,7 +389,7 @@ def wizard(color=True, retries=None, forcescan=False):
             item['ver'] = ver
             item['id'] = i['id']
             item['key'] = i['key']
-            if (ip == 0):
+            if ip == 0:
                 print("    %s[%s] - %s%s - %sError: No IP found%s" %
                       (subbold, name, dim, ip, alert, normal))
             else:


### PR DESCRIPTION
Hi, I use `pylint` a lot in my projects, and found a lot of low hanging fruit in the tinytuya codebase which I fixed up this morning.

A lot of this stuff is a matter of opinion, so feel free to close this PR with maximum prejudice 🥲 I also separated into different commits, so you could review each one and rebase out the ones you don't agree with 🤷 

* Remove trailing whitespace
* Pythonic imports
* Lazy logging calls
* Pythonic parentheses on if/return statements
* Fixed some indentation

I also included a `.pylintrc` which can be modified to taste - I use a lot of `pylint` ignores, to filter out the rules which are imo stylistic as opposed to objectively good practice:

> too-many-lines, line-too-long, too-many-ancestors, too-many-arguments, too-many-branches, too-many-instance-attributes, too-many-locals, too-many-nested-blocks, too-many-return-statements, too-many-statements, too-few-public-methods, ungrouped-imports

If you like where this is going, the next pass would be on the more nefarious pylint warnings (not all of which should be "fixed", of course):

* `bare-except`/`broad-except` which encourage good exception handling practice; hard to fix as they can change application behaviour
* `unspecified-encoding` which exists to help ensure files are written with consistent encoding on different platforms
* `redefined-outer-name`/`redefined-builtin` where a variable is clobbering an existing name; a can cause unexpected bugs