### PR TITLE
Apply new socket options to existing open sockets

### DIFF
--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -779,7 +779,10 @@ class XenonDevice(object):
     def set_socketNODELAY(self, nodelay):
         self.socketNODELAY = nodelay
         if self.socket:
-            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            if nodelay:
+                self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            else:
+                self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 0)
 
     def set_socketRetryLimit(self, limit):
         self.socketRetryLimit = limit

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -772,15 +772,22 @@ class XenonDevice(object):
 
     def set_socketPersistent(self, persist):
         self.socketPersistent = persist
+        if self.socket and not persist:
+            self.socket.close()
+            self.socket = None
 
     def set_socketNODELAY(self, nodelay):
         self.socketNODELAY = nodelay
+        if self.socket:
+            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
     def set_socketRetryLimit(self, limit):
         self.socketRetryLimit = limit
 
     def set_socketTimeout(self, s):
         self.connection_timeout = s
+        if self.socket:
+            self.socket.settimeout(s)
 
     def set_dpsUsed(self, dps_to_request):
         self.dps_to_request = dps_to_request


### PR DESCRIPTION
I'm using the socket timeout during receive() as a crude timer and need to change it on the fly, but set_socketTimeout() was not applying to existing open persistent sockets.  This update makes set_socketTimeout() and set_socketNODELAY() update immediately, and causes set_socketPersistent() to close the socket if persistent is changed to False and a socket is open.