### PR TITLE
Rework recv()

### DIFF
--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -360,9 +360,9 @@ def parse_header(data):
         #log.debug('Header prefix wrong! %08X != %08X', prefix, PREFIX_VALUE)
         raise DecodeError('Header prefix wrong! %08X != %08X' % (prefix, PREFIX_VALUE))
 
-    # sanity check. currently the max packet length is somewhere around 250 bytes
-    if payload_len > 300:
-        raise DecodeError('Header claims the packet size is over 300 bytes!  It is most likely corrupt.  Claimed size: %d bytes' % payload_len)
+    # sanity check. currently the max payload length is somewhere around 300 bytes
+    if payload_len > 1000:
+        raise DecodeError('Header claims the packet size is over 1000 bytes!  It is most likely corrupt.  Claimed size: %d bytes' % payload_len)
 
     return TuyaHeader(prefix, seqno, cmd, payload_len)
 
@@ -569,7 +569,7 @@ class XenonDevice(object):
             prefix_offset = data.find(PREFIX_BIN)
 
         header = parse_header(data)
-        remaining = header_len + ret_end_len + header.length - len(data)
+        remaining = header_len + header.length - len(data)
         if remaining > 0:
             data += self.socket.recv(remaining)
 
@@ -660,7 +660,7 @@ class XenonDevice(object):
                 time.sleep(0.1)
                 self._get_socket(True)
             except DecodeError as err:
-                log.debug("Error decoding received data - read retry %s/%", recv_retries, self.socketRetryLimit, exc_info=True)
+                log.debug("Error decoding received data - read retry %s/%s", recv_retries, self.socketRetryLimit, exc_info=True)
                 recv_retries += 1
                 if recv_retries > self.socketRetryLimit:
                     if partial_success:
@@ -709,7 +709,7 @@ class XenonDevice(object):
             result = self._decode_payload(msg.payload)
 
             if result is None:
-                log.debug("decode failed!")
+                log.debug("_decode_payload() failed!")
         except:
             log.debug("error unpacking or decoding tuya JSON payload")
             result = error_json(ERR_PAYLOAD)

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -555,6 +555,7 @@ class XenonDevice(object):
                 tries -= 1
                 if tries == 0:
                     raise DecodeError('No data received - connection closed?')
+                continue
             data += newdata
             length -= len(newdata)
             tries = 2

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -986,7 +986,7 @@ class XenonDevice(object):
         # if spaces are not removed device does not respond!
         payload = payload.replace(" ", "")
         payload = payload.encode("utf-8")
-        log.debug("building payload=%r", payload)
+        log.debug("building command %s payload=%r", command, payload)
 
         if self.version == 3.3:
             # expect to connect and then disconnect to set new

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -337,9 +337,6 @@ def unpack_message(data, header=None):
     crc, suffix = struct.unpack(MESSAGE_END_FMT, payload[-end_len:])
     have_crc = binascii.crc32(data[:(header_len+header.length)-end_len]) & 0xFFFFFFFF
 
-    if header.prefix != PREFIX_VALUE:
-        log.debug('Header prefix wrong! %08X != %08X', header.prefix, PREFIX_VALUE)
-
     if suffix != SUFFIX_VALUE:
         log.debug('Suffix prefix wrong! %08X != %08X', suffix, SUFFIX_VALUE)
 
@@ -357,6 +354,14 @@ def parse_header(data):
     prefix, seqno, cmd, payload_len = struct.unpack(
         MESSAGE_HEADER_FMT, data[:header_len]
     )
+
+    if prefix != PREFIX_VALUE:
+        #log.debug('Header prefix wrong! %08X != %08X', prefix, PREFIX_VALUE)
+        raise DecodeError('Header prefix wrong! %08X != %08X' % (prefix, PREFIX_VALUE))
+
+    # sanity check. currently the max packet length is somewhere around 250 bytes
+    if payload_len > 300:
+        raise DecodeError('Header claims the packet size is over 300 bytes!  It is most likely corrupt.  Claimed size: %d bytes' % payload_len)
 
     return TuyaHeader(prefix, seqno, cmd, payload_len)
 

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -565,7 +565,11 @@ class XenonDevice(object):
             else:
                 data = data[prefix_offset:]
 
-            data += self.socket.recv(header_len+ret_end_len-len(data))
+            newdata = self.socket.recv(header_len+ret_end_len-len(data))
+            if len(newdata) == 0:
+                # connection closed?
+                raise DecodeError('No data received - connection closed?')
+            data += newdata
             prefix_offset = data.find(PREFIX_BIN)
 
         header = parse_header(data)

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -566,7 +566,7 @@ class XenonDevice(object):
                 data = data[prefix_offset:]
 
             newdata = self.socket.recv(header_len+ret_end_len-len(data))
-            if len(newdata) == 0:
+            if not newdata or len(newdata) == 0:
                 # connection closed?
                 raise DecodeError('No data received - connection closed?')
             data += newdata


### PR DESCRIPTION
This PR reworks socket receiving (again).  It separates read retries from send retries and tries a bit harder to receive a valid message.

If a null payload is received, it treats it as an ACK and will not resend a command even if no actual payload is ever received.
If a null payload or corrupt message is received, it retries the read (but not the send).
If a generic exception or socket timeout is encountered without first receiving a null payload, it retries the send.  (This matches the existing behavior, it is not a change.)
If a generic exception is encountered after receiving a null payload, it retries the read (but not the send).
If a socket timeout is encountered after receiving a null payload, it immediately returns None.

Decryption failures now return a json error instead of None as that seems to be the more correct thing to do.  If it is a null payload then decryption is skipped and None is returned.

In addition, it now searches the received data for the message start prefix.  This could help with temperamental bulbs/devices if they send an extra NUL or other garbage before the start prefix or if a message somehow "tears" into 2 packets with the 2nd half badly delayed.