### PR TITLE
skip DPS detection if it has already been set

### DIFF
--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -820,8 +820,9 @@ class XenonDevice(object):
         if version == 3.2: # 3.2 behaves like 3.3 with device22
                 self.version = 3.3  
                 self.dev_type="device22"  
-                self.dps_to_request = {"1": None}
-                self.dps_to_request = self.detect_available_dps()
+                if self.dps_to_request == {}:
+                    self.dps_to_request = {"1": None}
+                    self.dps_to_request = self.detect_available_dps()
 
     def set_socketPersistent(self, persist):
         self.socketPersistent = persist


### PR DESCRIPTION
since detect_available_dps() function takes considerable amount of time to run, skip it if DPS has already been set for a device with set_dpsUsed() function