### PR TITLE
Add Pronto/NEC/Samsung IR code conversion functions to IRRemoteControlDevice

### DIFF
--- a/examples/Contrib/IRRemoteControlDevice-example.py
+++ b/examples/Contrib/IRRemoteControlDevice-example.py
@@ -18,27 +18,25 @@ from time import sleep
 # discrete on/off codes for Samsung
 pronto_samsung_on = '0000 006D 0000 0022 00AC 00AC 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0015 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0689'
 pronto_samsung_off = '0000 006D 0000 0022 00AC 00AC 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0689'
-
 pulses_samsung_on = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_on )
 pulses_samsung_off = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_off )
-
 print( 'Samsung on code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_on )[0] )
 print( 'Samsung off code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_off )[0] )
 
 # discrete on/off codes for LG
 hex_lg_on = 0x20DF23DC
 hex_lg_off = 0x20DFA35C
-
 pulses_lg_on = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_on )
 pulses_lg_off = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_off )
-
 print( 'LG on code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_on )[0] )
 print( 'LG off code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_off )[0] )
 
 ir = Contrib.IRRemoteControlDevice( 'abcdefghijklmnop123456', '172.28.321.475', '1234567890123abc' )
 
-# turn the tv on
+# turn the Samsung tv on
 ir.send_button( ir.pulses_to_base64( pulses_samsung_on ) )
+# turn the LG tv on
+ir.send_button( ir.pulses_to_base64( pulses_lg_on ) )
 
 print("Press button on your remote control")
 button = ir.receive_button(timeout=15)

--- a/examples/Contrib/IRRemoteControlDevice-example.py
+++ b/examples/Contrib/IRRemoteControlDevice-example.py
@@ -21,7 +21,9 @@ pronto_samsung_off = '0000 006D 0000 0022 00AC 00AC 0015 0040 0015 0040 0015 004
 pulses_samsung_on = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_on )
 pulses_samsung_off = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_off )
 print( 'Samsung on code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_on )[0] )
+# Samsung on code: {'type': 'samsung', 'uint32': 3772815718, 'address': 224, 'data': 153, 'hex': 'E0E09966'}
 print( 'Samsung off code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_off )[0] )
+# Samsung off code: {'type': 'samsung', 'uint32': 3772783078, 'address': 224, 'data': 25, 'hex': 'E0E019E6'}
 
 # discrete on/off codes for LG
 hex_lg_on = 0x20DF23DC
@@ -29,7 +31,9 @@ hex_lg_off = 0x20DFA35C
 pulses_lg_on = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_on )
 pulses_lg_off = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_off )
 print( 'LG on code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_on )[0] )
+# LG on code: {'type': 'nec', 'uint32': 551494620, 'address': 32, 'data': 35, 'hex': '20DF23DC'}
 print( 'LG off code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_off )[0] )
+# LG off code: {'type': 'nec', 'uint32': 551527260, 'address': 32, 'data': 163, 'hex': '20DFA35C'}
 
 ir = Contrib.IRRemoteControlDevice( 'abcdefghijklmnop123456', '172.28.321.475', '1234567890123abc' )
 

--- a/examples/Contrib/IRRemoteControlDevice-example.py
+++ b/examples/Contrib/IRRemoteControlDevice-example.py
@@ -15,7 +15,30 @@ from time import sleep
 
 # tinytuya.set_debug(toggle=True, color=True)
 
+# discrete on/off codes for Samsung
+pronto_samsung_on = '0000 006D 0000 0022 00AC 00AC 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0015 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0689'
+pronto_samsung_off = '0000 006D 0000 0022 00AC 00AC 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0040 0015 0040 0015 0015 0015 0015 0015 0040 0015 0040 0015 0015 0015 0689'
+
+pulses_samsung_on = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_on )
+pulses_samsung_off = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_off )
+
+print( 'Samsung on code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_on )[0] )
+print( 'Samsung off code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_off )[0] )
+
+# discrete on/off codes for LG
+hex_lg_on = 0x20DF23DC
+hex_lg_off = 0x20DFA35C
+
+pulses_lg_on = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_on )
+pulses_lg_off = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_off )
+
+print( 'LG on code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_on )[0] )
+print( 'LG off code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_off )[0] )
+
 ir = Contrib.IRRemoteControlDevice( 'abcdefghijklmnop123456', '172.28.321.475', '1234567890123abc' )
+
+# turn the tv on
+ir.send_button( ir.pulses_to_base64( pulses_samsung_on ) )
 
 print("Press button on your remote control")
 button = ir.receive_button(timeout=15)

--- a/examples/Contrib/IRRemoteControlDevice-example.py
+++ b/examples/Contrib/IRRemoteControlDevice-example.py
@@ -21,9 +21,9 @@ pronto_samsung_off = '0000 006D 0000 0022 00AC 00AC 0015 0040 0015 0040 0015 004
 pulses_samsung_on = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_on )
 pulses_samsung_off = Contrib.IRRemoteControlDevice.pronto_to_pulses( pronto_samsung_off )
 print( 'Samsung on code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_on )[0] )
-# Samsung on code: {'type': 'samsung', 'uint32': 3772815718, 'address': 224, 'data': 153, 'hex': 'E0E09966'}
+# Samsung on code: {'type': 'samsung', 'uint32': 3772815718, 'address': 7, 'data': 153, 'hex': 'E0E09966'}
 print( 'Samsung off code:', Contrib.IRRemoteControlDevice.pulses_to_samsung( pulses_samsung_off )[0] )
-# Samsung off code: {'type': 'samsung', 'uint32': 3772783078, 'address': 224, 'data': 25, 'hex': 'E0E019E6'}
+# Samsung off code: {'type': 'samsung', 'uint32': 3772783078, 'address': 7, 'data': 152, 'hex': 'E0E019E6'}
 
 # discrete on/off codes for LG
 hex_lg_on = 0x20DF23DC
@@ -31,9 +31,9 @@ hex_lg_off = 0x20DFA35C
 pulses_lg_on = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_on )
 pulses_lg_off = Contrib.IRRemoteControlDevice.nec_to_pulses( hex_lg_off )
 print( 'LG on code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_on )[0] )
-# LG on code: {'type': 'nec', 'uint32': 551494620, 'address': 32, 'data': 35, 'hex': '20DF23DC'}
+# LG on code: {'type': 'nec', 'uint32': 551494620, 'address': 4, 'data': 196, 'hex': '20DF23DC'}
 print( 'LG off code:', Contrib.IRRemoteControlDevice.pulses_to_nec( pulses_lg_off )[0] )
-# LG off code: {'type': 'nec', 'uint32': 551527260, 'address': 32, 'data': 163, 'hex': '20DFA35C'}
+# LG off code: {'type': 'nec', 'uint32': 551527260, 'address': 4, 'data': 197, 'hex': '20DFA35C'}
 
 ir = Contrib.IRRemoteControlDevice( 'abcdefghijklmnop123456', '172.28.321.475', '1234567890123abc' )
 

--- a/tinytuya/Contrib/IRRemoteControlDevice.py
+++ b/tinytuya/Contrib/IRRemoteControlDevice.py
@@ -323,6 +323,7 @@ class IRRemoteControlDevice(Device):
 
     @staticmethod
     def pronto_to_pulses( pronto ):
+        ret = [ ]
         pronto = [int(x, 16) for x in pronto.split(' ')]
         ptype = pronto[0]
         timebase = pronto[1]
@@ -330,13 +331,12 @@ class IRRemoteControlDevice(Device):
         pair2_len = pronto[3]
         if ptype != 0:
             # only raw (learned) codes are handled
-            return None
+            return ret
         if timebase < 90 or timebase > 139:
             # only 38 kHz is supported?
-            return None
+            return ret
         pronto = pronto[4:]
         timebase *= 0.241246
-        ret = [ ]
         for i in range(0, pair1_len*2, 2):
             ret += [round(pronto[i] * timebase), round(pronto[i+1] * timebase)]
         pronto = pronto[pair1_len*2:]


### PR DESCRIPTION
Not sure what the procedure for updating someone else's Contrib is...

All my IR codes are stored as hex (i.e. 0x40BEFF00 for an Element TV discrete power on command) or as Pronto, so I added functions to convert to/from them to make it easier to use.