### PR TITLE
Get local key from devices.json if not provided

### DIFF
--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -114,7 +114,7 @@ class BulbDevice(Device):
     has_colourtemp = False
     has_colour = False
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", version=None):
+    def __init__(self, dev_id, address=None, local_key="", dev_type="default", version=None):
         super(BulbDevice, self).__init__(dev_id, address, local_key, dev_type, version=version)
 
     @staticmethod

--- a/tinytuya/Contrib/DoorbellDevice.py
+++ b/tinytuya/Contrib/DoorbellDevice.py
@@ -81,7 +81,7 @@ class DoorbellDevice(Device):
         "169": "motion_area",         # String ["maxlen":255]
     }
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", version=3.1):
+    def __init__(self, dev_id, address=None, local_key="", dev_type="default", version=3.1):
         super(DoorbellDevice, self).__init__(dev_id, address, local_key, dev_type, version=version)
 
     def set_basic_indicator(self, val=True, nowait=False):

--- a/tinytuya/Contrib/IRRemoteControlDevice.py
+++ b/tinytuya/Contrib/IRRemoteControlDevice.py
@@ -95,7 +95,7 @@ class IRRemoteControlDevice(Device):
     NSDP_HEAD = "head"             # Actually used but not documented
     NSDP_KEY1 = "key1"             # Actually used but not documented
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", persist=True, version=3.3):
+    def __init__(self, dev_id, address=None, local_key="", dev_type="default", persist=True, version=3.3):
         super(IRRemoteControlDevice, self).__init__(dev_id, address, local_key, dev_type, version=version)
 
     def receive_button( self, timeout ):

--- a/tinytuya/Contrib/SocketDevice.py
+++ b/tinytuya/Contrib/SocketDevice.py
@@ -60,7 +60,7 @@ class SocketDevice(Device):
     DPS_POWER = '19'
     DPS_VOLTAGE = '20'
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", version=3.1):
+    def __init__(self, dev_id, address=None, local_key="", dev_type="default", version=3.1):
         super(SocketDevice, self).__init__(dev_id, address, local_key, dev_type, version=version)
 
     def get_energy_consumption(self):

--- a/tinytuya/Contrib/ThermostatDevice.py
+++ b/tinytuya/Contrib/ThermostatDevice.py
@@ -262,7 +262,7 @@ class ThermostatDevice(Device):
         '130': { 'name': 'weather_forcast' }
         }
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", persist=True, version=3.3):
+    def __init__(self, dev_id, address=None, local_key="", dev_type="default", persist=True, version=3.3):
         super(ThermostatDevice, self).__init__(dev_id, address, local_key, dev_type, version=version)
         # set persistant so we can receive sensor broadcasts
         if persist:

--- a/tinytuya/CoverDevice.py
+++ b/tinytuya/CoverDevice.py
@@ -60,7 +60,7 @@ class CoverDevice(Device):
         "101": "backlight",
     }
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", version=3.1):
+    def __init__(self, dev_id, address=None, local_key="", dev_type="default", version=3.1):
         super(CoverDevice, self).__init__(dev_id, address, local_key, dev_type, version=version)
 
     def open_cover(self, switch=1, nowait=False):

--- a/tinytuya/OutletDevice.py
+++ b/tinytuya/OutletDevice.py
@@ -50,7 +50,7 @@ class OutletDevice(Device):
         local_key (str, optional): The encryption key. Defaults to None.
     """
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", version=3.1):
+    def __init__(self, dev_id, address=None, local_key="", dev_type="default", version=3.1):
         super(OutletDevice, self).__init__(dev_id, address, local_key, dev_type, version=version)
 
     def set_dimmer(self, percentage=None, value=None, dps_id=3, nowait=False):


### PR DESCRIPTION
This adds a helper function to get the device data from devcies.json, and uses it to look up the local key if it is not provided.  It also makes the IP address argument optional (it will try to find the device if not provided) .  This means if you have a devices.json file containing the device key and the device is broadcasting on the local network, all you need to do is:

```python
d = tinytuya.OutletDevice( '0123456789abcdef0123' )
```