### PR TITLE
Add Climate device module for portable air conditioners. 

### DIFF
--- a/tinytuya/Contrib/ClimateDevice.py
+++ b/tinytuya/Contrib/ClimateDevice.py
@@ -1,0 +1,151 @@
+from tinytuya.core import Device
+
+"""
+ Python module to interface with Tuya Portable Air Conditioner devices
+
+ Local Control Classes
+    ClimateDevice(dev_id, address, local_key=None, dev_type='default', version=3.3)
+
+ Functions
+    ClimateDevice:
+        status_json()
+        get_room_temperature()
+        get_target_temperature()
+        set_target_temperature()
+        get_operating_mode()
+        set_operating_mode()
+        get_fan_speed()
+        set_fan_speed()
+        get_current_state()
+        get_timer()
+        set_timer()
+        get_temperature_unit()
+        set_temperature_unit()
+    Inherited
+        json = status()                    # returns json payload
+        set_version(version)               # 3.1 [default] or 3.3
+        set_socketPersistent(False/True)   # False [default] or True
+        set_socketNODELAY(False/True)      # False or True [default]
+        set_socketRetryLimit(integer)      # retry count limit [default 5]
+        set_socketTimeout(timeout)         # set connection timeout in seconds [default 5]
+        set_dpsUsed(dps_to_request)        # add data points (DPS) to request
+        add_dps_to_request(index)          # add data point (DPS) index set to None
+        set_retry(retry=True)              # retry if response payload is truncated
+        set_status(on, switch=1, nowait)   # Set status of switch to 'on' or 'off' (bool)
+        set_value(index, value, nowait)    # Set int value of any index.
+        heartbeat(nowait)                  # Send heartbeat to device
+        updatedps(index=[1], nowait)       # Send updatedps command to device
+        turn_on(switch=1, nowait)          # Turn on device / switch #
+        turn_off(switch=1, nowait)         # Turn off
+        set_timer(num_secs, nowait)        # Set timer for num_secs
+        set_debug(toggle, color)           # Activate verbose debugging output
+        set_sendWait(num_secs)             # Time to wait after sending commands before pulling response
+        detect_available_dps()             # Return list of DPS available from device
+        generate_payload(command, data)    # Generate TuyaMessage payload for command with data
+        send(payload)                      # Send payload to device (do not wait for response)
+        receive()
+"""
+
+
+class ClimateDevice(Device):
+    """
+    Represents a Tuya based Air Conditioner
+
+    Args:
+        dev_id (str): The device id.
+        address (str): The network address.
+        local_key (str, optional): The encryption key. Defaults to None.
+        version (float, optional): Tuya Device Version (look at Device.set_version)
+    """
+
+    DPS_POWER = "1"
+    DPS_SET_TEMP = "2"
+    DPS_CUR_TEMP = "3"
+    DPS_MODE = "4"
+    DPS_FAN = "5"
+    DPS_TEMP_UNIT = "19"
+    DPS_TIMER = "22"
+    DPS_SLEEP_PRESET = "25"
+    DPS_SWING = "30"
+    DPS_STATE = "101"
+
+    def __init__(self, dev_id, address, local_key="", dev_type="default", version=3.3):
+        super(ClimateDevice, self).__init__(
+            dev_id, address, local_key, dev_type, version=version
+        )
+
+    def status_json(self):
+        """Wrapper around status() that replace DPS indices with human readable labels."""
+        status = self.status()["dps"]
+        return {
+            "Power On": status[self.DPS_POWER],
+            "Set temperature": status[self.DPS_SET_TEMP],
+            "Current temperature": status[self.DPS_CUR_TEMP],
+            "Fan speed": status[self.DPS_FAN],
+            "Temperature unit": status[self.DPS_TEMP_UNIT],
+            "Sleep preset On": status[self.DPS_SLEEP_PRESET],
+            "Swing On": status[self.DPS_SWING],
+            "Operating mode": status[self.DPS_STATE],
+            "Timer left": status[self.DPS_TIMER],
+        }
+
+    def get_room_temperature(self):
+        status = self.status()["dps"]
+        return status[self.DPS_CUR_TEMP]
+
+    def get_target_temperature(self):
+        status = self.status()["dps"]
+        return status[self.DPS_SET_TEMP]
+
+    def set_target_temperature(self, t):
+        def is_float(f):
+            try:
+                float(f)
+                return True
+            except ValueError:
+                return False
+
+        # non numeric values can confuse the unit
+        if not is_float(t):
+            return
+
+        self.set_value(self.DPS_SET_TEMP, t)
+
+    def get_operating_mode(self):
+        status = self.status()["dps"]
+        return status[self.DPS_MODE]
+
+    def set_operating_mode(self, mode):
+        if mode not in ("cold", "hot", "dehumidify"):
+            return
+        self.set_value(self.DPS_MODE, mode)
+
+    def get_fan_speed(self):
+        status = self.status()["dps"]
+        return status[self.DPS_FAN]
+
+    def set_fan_speed(self, value):
+        if value not in ("auto", "low", "middle", "high"):
+            return
+        self.set_value(self.DPS_FAN, value)
+
+    def get_current_state(self):
+        status = self.status()["dps"]
+        return "On" if status[self.DPS_POWER] else "Off"
+
+    def get_timer(self):
+        status = self.status()["dps"]
+        return status[self.DPS_TIMER]
+
+    def set_timer(self, delay):
+        if delay < 0 or delay > 24:
+            return
+        self.set_value(self.DPS_TIMER, delay)
+
+    def get_temperature_unit(self):
+        status = self.status()["dps"]
+        return status[self.DPS_TEMP_UNIT]
+
+    def set_temperature_unit(self, unit):
+        # no matter what the unit is, the Fral Supercool 19.2SC report temperatures in Celsius. The unit seems to influence only the display on the unit.
+        self.set_value(self.DPS_TEMP_UNIT, unit)

--- a/tinytuya/Contrib/__init__.py
+++ b/tinytuya/Contrib/__init__.py
@@ -3,5 +3,6 @@ from .ThermostatDevice import ThermostatDevice
 from .IRRemoteControlDevice import IRRemoteControlDevice
 from .SocketDevice import SocketDevice
 from .DoorbellDevice import DoorbellDevice
+from .ClimateDevice import ClimateDevice
 
-DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice"]
+DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice", "ClimateDevice"]


### PR DESCRIPTION
I tested only the Fral Supercool 19.2SC, but it seems it should support more devices. For example this one use the same DPS:
https://github.com/make-all/tuya-local/blob/main/custom_components/tuya_local/devices/eberg_qubo_q40hd_heatpump.yaml

