### PR TITLE
Misc updates to find_device(), wizard, and repr(device)

### DIFF
--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -220,10 +220,18 @@ class Cloud(object):
         response_dict = self._tuyaplatform(uri)
 
         if not response_dict['success']:
+            if 'code' not in response_dict:
+                response_dict['code'] = -1
+            if 'msg' not in response_dict:
+                response_dict['msg'] = 'Unknown Error'
             log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
-            return None
+            return error_json(
+                ERR_CLOUD,
+                "Error from Tuya Cloud: Code %r: %r" % (response_dict['code'], response_dict['msg'])
+            )
+
         uid = response_dict['result']['uid']
         return uid
 
@@ -239,6 +247,9 @@ class Cloud(object):
                 ERR_CLOUD,
                 "Unable to get device list"
             )
+        elif isinstance( uid, dict):
+            return uid
+
         # Use UID to get list of all Devices for User
         uri = 'users/%s/devices' % uid
         json_data = self._tuyaplatform(uri)

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -625,7 +625,8 @@ class XenonDevice(object):
 
     def __repr__(self):
         # FIXME can do better than this
-        return "%r" % ((self.id, self.address),)
+        return ("%s( %r, address=%r, local_key=%r, dev_type=%r, connection_timeout=%r, version=%r, persist=%r )" %
+                (self.__class__.__name__, self.id, self.address, self.real_local_key.decode(), self.dev_type, self.connection_timeout, self.version, self.socketPersistent))
 
     def _get_socket(self, renew):
         if renew and self.socket is not None:

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -412,7 +412,7 @@ def find_device(dev_id=None, address=None):
         address = The IP address you are tring to find the Device ID for
 
     Response:
-        (ip, version, {broadcast data})
+        {'ip':<ip>, 'version':<version>, 'id':<id>, 'product_id':<product_id>, 'data':<broadcast data>}
     """
     if dev_id is None and address is None:
         return (None, None, None)
@@ -430,9 +430,9 @@ def find_device(dev_id=None, address=None):
 
     deadline = time.time() + SCANTIME
     selecttime = SCANTIME
-    ret = (None, None, None)
+    ret = None
 
-    while (ret[0] is None) and (selecttime > 0):
+    while (ret is None) and (selecttime > 0):
         rd, _, _ = select.select( [client, clients], [], [], selecttime )
         for sock in rd:
             try:
@@ -454,19 +454,21 @@ def find_device(dev_id=None, address=None):
                 ip = result["ip"]
                 gwId = result["gwId"]
                 version = result["version"]
+                product_id = '' if 'productKey' not in result else result['productKey']
                 log.debug( 'find() received broadcast from %r: %r', ip, result )
             except:
                 result = {"ip": ip}
                 log.debug( 'find() failed to decode broadcast from %r: %r', addr, data )
+                continue
 
             # Check to see if we are only looking for one device
             if dev_id and gwId == dev_id:
                 # We found it by dev_id!
-                ret = (ip, version, result)
+                ret = {'ip':ip, 'version':version, 'id':gwId, 'product_id':product_id, 'data':result}
                 break
             elif address and address == ip:
                 # We found it by ip!
-                ret = (ip, version, result)
+                ret = {'ip':ip, 'version':version, 'id':gwId, 'product_id':product_id, 'data':result}
                 break
 
         selecttime = deadline - time.time()
@@ -474,6 +476,8 @@ def find_device(dev_id=None, address=None):
     # while
     clients.close()
     client.close()
+    if ret is None:
+        ret = {'ip':None, 'version':None, 'id':None, 'product_id':None, 'data':{}}
     log.debug( 'find() is returning: %r', ret )
     return ret
 
@@ -598,12 +602,12 @@ class XenonDevice(object):
 
         if (not address) or address == "Auto" or address == "0.0.0.0":
             # try to determine IP address automatically
-            (addr, ver, bcast_data) = find_device(dev_id)
-            if addr is None:
+            bcast_data = find_device(dev_id)
+            if bcast_data['ip'] is None:
                 log.debug("Unable to find device on network (specify IP address)")
                 raise Exception("Unable to find device on network (specify IP address)")
-            self.address = addr
-            self.set_version(float(ver))
+            self.address = bcast_data['ip']
+            self.set_version(float(bcast_data['version']))
             time.sleep(0.1)
         elif version:
             self.set_version(float(version))
@@ -1194,8 +1198,8 @@ class XenonDevice(object):
         Response:
             (ip, version)
         """
-        (ip, ver, bcast_data) = find_device(dev_id=did)
-        return (ip, ver)
+        bcast_data = find_device(dev_id=did)
+        return (bcast_data['ip'], bcast_data['version'])
 
     def generate_payload(self, command, data=None, gwId=None, devId=None, uid=None):
         """

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -171,11 +171,19 @@ def wizard(color=True, retries=None, forcescan=False):
 
     # on auth error, cloud.token is a dict and will cause getdevices() to implode
     if isinstance( cloud.token, dict):
-        print('\n\n' + bold + 'Error from Tuya server: ' + dim + cloud.token['Payload'])
+        err = cloud.token['Payload'] if 'Payload' in cloud.token else 'Unknown Error'
+        print('\n\n' + bold + 'Error from Tuya server: ' + dim + err)
+        print('Check API Key and Secret')
         return
 
     # Get UID from sample Device ID
     json_data = cloud.getdevices( True )
+
+    if 'result' not in json_data:
+        err = json_data['Payload'] if 'Payload' in json_data else 'Unknown Error'
+        print('\n\n' + bold + 'Error from Tuya server: ' + dim + err)
+        print('Check DeviceID and Region')
+        return
 
     if forcescan:
         # Force Scan - Get list of all local ip addresses


### PR DESCRIPTION
The way find_device() returned a tuple didn't sit right with me, so I made it return a dict instead.  This will also allow expanding the info returned in the future without breaking anything.  I screwed up and forgot to submit a PR for this before 1.7.1 dropped, but hopefully it's recent enough that this breaking change won't be too bad.

Wizard now detects more cloud errors, namely wrong Regions and Device IDs.  Fixes #195 

I also updated __repr__ to include a bit more information and what type of device it is.  Still not perfect and is missing some info (such as nodelay), but it's a lot better.