### PR TITLE
Restore reference to 'self' in __init__() functions

### DIFF
--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -105,11 +105,11 @@ class BulbDevice(Device):
     has_colourtemp = False
     has_colour = False
 
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         # set the default version to None so we do not immediately connect and call status()
         if 'version' not in kwargs or not kwargs['version']:
             kwargs['version'] = None
-        super(BulbDevice, args[0]).__init__(*args[1:], **kwargs)
+        super(BulbDevice, self).__init__(*args, **kwargs)
 
     @staticmethod
     def _rgb_to_hexvalue(r, g, b, bulb="A"):

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -254,7 +254,7 @@ class Cloud(object):
         uri = 'users/%s/devices' % uid
         json_data = self._tuyaplatform(uri)
 
-        if verbose:
+        if verbose or 'result' not in json_data:
             return json_data
         else:
             # Filter to only Name, ID and Key

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -254,7 +254,7 @@ class Cloud(object):
         uri = 'users/%s/devices' % uid
         json_data = self._tuyaplatform(uri)
 
-        if verbose or 'result' not in json_data:
+        if verbose or not json_data or 'result' not in json_data:
             return json_data
         else:
             # Filter to only Name, ID and Key

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -254,8 +254,13 @@ class Cloud(object):
         uri = 'users/%s/devices' % uid
         json_data = self._tuyaplatform(uri)
 
-        if verbose or not json_data or 'result' not in json_data:
+        if verbose:
             return json_data
+        elif not json_data or 'result' not in json_data:
+            return error_json(
+                ERR_CLOUD,
+                "Unable to get device list"
+            )
         else:
             # Filter to only Name, ID and Key
             return self.filter_devices( json_data['result'] )

--- a/tinytuya/Contrib/ClimateDevice.py
+++ b/tinytuya/Contrib/ClimateDevice.py
@@ -4,7 +4,9 @@ from tinytuya.core import Device
  Python module to interface with Tuya Portable Air Conditioner devices
 
  Local Control Classes
-    ClimateDevice(dev_id, ...)
+    ClimateDevice(..., version=3.3)
+        This class uses a default version of 3.3
+        See OutletDevice() for the other constructor arguments
 
  Functions
     ClimateDevice:

--- a/tinytuya/Contrib/ClimateDevice.py
+++ b/tinytuya/Contrib/ClimateDevice.py
@@ -4,7 +4,7 @@ from tinytuya.core import Device
  Python module to interface with Tuya Portable Air Conditioner devices
 
  Local Control Classes
-    ClimateDevice(dev_id, address, local_key=None, dev_type='default', version=3.3)
+    ClimateDevice(dev_id, ...)
 
  Functions
     ClimateDevice:
@@ -50,12 +50,6 @@ from tinytuya.core import Device
 class ClimateDevice(Device):
     """
     Represents a Tuya based Air Conditioner
-
-    Args:
-        dev_id (str): The device id.
-        address (str): The network address.
-        local_key (str, optional): The encryption key. Defaults to None.
-        version (float, optional): Tuya Device Version (look at Device.set_version)
     """
 
     DPS_POWER = "1"
@@ -69,10 +63,11 @@ class ClimateDevice(Device):
     DPS_SWING = "30"
     DPS_STATE = "101"
 
-    def __init__(self, dev_id, address, local_key="", dev_type="default", version=3.3):
-        super(ClimateDevice, self).__init__(
-            dev_id, address, local_key, dev_type, version=version
-        )
+    def __init__(self, *args, **kwargs):
+        # set the default version to 3.3 as there are no 3.1 devices
+        if 'version' not in kwargs or not kwargs['version']:
+            kwargs['version'] = 3.3
+        super(ClimateDevice, self).__init__(*args, **kwargs)
 
     def status_json(self):
         """Wrapper around status() that replace DPS indices with human readable labels."""

--- a/tinytuya/Contrib/IRRemoteControlDevice.py
+++ b/tinytuya/Contrib/IRRemoteControlDevice.py
@@ -96,11 +96,11 @@ class IRRemoteControlDevice(Device):
     NSDP_HEAD = "head"             # Actually used but not documented
     NSDP_KEY1 = "key1"             # Actually used but not documented
 
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         # set the default version to 3.3 as there are no 3.1 devices
         if 'version' not in kwargs or not kwargs['version']:
             kwargs['version'] = 3.3
-        super(IRRemoteControlDevice, args[0]).__init__(*args[1:], **kwargs)
+        super(IRRemoteControlDevice, self).__init__(*args, **kwargs)
 
     def receive_button( self, timeout ):
         log.debug("Receiving button")

--- a/tinytuya/Contrib/ThermostatDevice.py
+++ b/tinytuya/Contrib/ThermostatDevice.py
@@ -258,14 +258,14 @@ class ThermostatDevice(Device):
         '130': { 'name': 'weather_forcast' }
         }
 
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         # set the default version to 3.3 as there are no 3.1 devices
         if 'version' not in kwargs or not kwargs['version']:
             kwargs['version'] = 3.3
         # set persistant so we can receive sensor broadcasts
         if 'persist' not in kwargs:
             kwargs['persist'] = True
-        super(ThermostatDevice, args[0]).__init__(*args[1:], **kwargs)
+        super(ThermostatDevice, self).__init__(*args, **kwargs)
 
         self.high_resolution = None
         self.schedule = None

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -620,10 +620,13 @@ class XenonDevice(object):
 
     def __del__(self):
         # In case we have a lingering socket connection, close it
-        if self.socket is not None:
-            # self.socket.shutdown(socket.SHUT_RDWR)
-            self.socket.close()
-            self.socket = None
+        try:
+            if self.socket:
+                # self.socket.shutdown(socket.SHUT_RDWR)
+                self.socket.close()
+                self.socket = None
+        except:
+            pass
 
     def __repr__(self):
         # FIXME can do better than this
@@ -1287,8 +1290,8 @@ class XenonDevice(object):
 
 
 class Device(XenonDevice):
-    def __init__(*args, **kwargs):
-        super(Device, args[0]).__init__(*args[1:], **kwargs)
+    #def __init__(self, *args, **kwargs):
+    #    super(Device, self).__init__(*args, **kwargs)
 
     def status(self):
         """Return device status."""


### PR DESCRIPTION
Fixes #205 by changing \_\_init\_\_() to include "self".  All other devices using \_\_init\_\_() were also updated to keep everything consistent.  A tweak to Cloud.getdevices() to add some sanity checking is also included.