### PR TITLE
Rework Cloud log start/end times, and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,13 +392,15 @@ result = c.sendcommand(id,commands)
 print("Results\n:", result)
 ```
 
-Up to one week of device logs can also be pulled from the Cloud.  By default getdevicelog() will pull 1 day of logs or 100 log entries, whichever comes first.
+Up to one week of device logs can also be pulled from the Cloud.  By default getdevicelog() will pull 1 day of logs or 100 log entries, whichever comes first.  The returned timestamps are unixtime*1000, and event_id 7 (data report) will probably be the most useful.
 
 ```python
 import tinytuya
 import json
 
 c = tinytuya.Cloud()
+#r = c.getdevicelog( '00112233445566778899', start=-1, end=0, size=100 )
+#r = c.getdevicelog( '00112233445566778899', start=1669990000, end=1669990300, size=20 )
 r = c.getdevicelog( '00112233445566778899' )
 print( json.dumps(r, indent=2) )
 ```

--- a/examples/cloud.py
+++ b/examples/cloud.py
@@ -64,3 +64,19 @@ print("Sending command...")
 result = c.sendcommand(id,commands)
 print("Results\n:", result)
 
+# Get device logs
+# Note: the returned timestamps are unixtime*1000
+# event_id 7 (data report) will probably be the most useful
+# More information can be found at https://developer.tuya.com/en/docs/cloud/cbea13f274?id=Kalmcohrembze
+
+# Get device logs from the last day
+result = c.getdevicelog(id)
+print("Device logs:\n", result)
+
+# Get device logs from 7 days ago through 5 days ago (2 days worth)
+#result = c.getdevicelog(id, start=-7, end=-5)
+#print("Device logs:\n", result)
+
+# Get device logs for one day ending an hour ago
+#result = c.getdevicelog(id, end=time.time() - 3600)
+#print("Device logs:\n", result)

--- a/examples/zigbee_gateway.py
+++ b/examples/zigbee_gateway.py
@@ -1,0 +1,40 @@
+import tinytuya
+import time
+
+# Zigbee Gateway support uses a parent/child model where a parent gateway device is
+#  connected and then one or more children are added.
+
+# configure the parent device
+gw = tinytuya.Device( 'eb...4', address=None, local_key='aabbccddeeffgghh', persist=True, version=3.3 )
+
+print( 'GW IP found:', gw.address )
+
+# configure one or more children.  Every dev_id must be unique!
+zigbee1 = tinytuya.OutletDevice( 'eb14...w', cid='0011223344556601', parent=gw )
+zigbee2 = tinytuya.OutletDevice( 'eb04...l', cid='0011223344556689', parent=gw )
+
+print(zigbee1.status())
+print(zigbee2.status())
+
+print(" > Begin Monitor Loop <")
+pingtime = time.time() + 9
+
+while(True):
+    if( pingtime <= time.time() ):
+        payload = gw.generate_payload(tinytuya.HEART_BEAT)
+        gw.send(payload)
+        pingtime = time.time() + 9
+
+    # receive from the gateway object to get updates for all sub-devices
+    print('recv:')
+    data = gw.receive()
+    print( data )
+
+    # data['device'] contains a reference to the device object
+    if data and 'device' in data and data['device'] == zigbee1:
+        print('toggling device state')
+        time.sleep(1)
+        if data['dps']['1']:
+            data['device'].turn_off(nowait=True)
+        else:
+            data['device'].turn_on(nowait=True)


### PR DESCRIPTION
I noticed the Cloud documentation calls for 13-digit timestamps, however I was sending 10-digit UNIX timestamps.  It seemed to work fine, but I decided it would be better to match the official documentation.  So it now sends a 13-digit `int(time.time() * 1000)`.  I also reworked it so you can pass a negative number for that many days ago (i.e. -2 means 2 days ago) and added automatic server time offset compensation.

Documentation for the above as well as the Zigbee Gateway example were added.