### PR TITLE
Support for v3.5: there was an attempt

### DIFF
--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -444,7 +444,7 @@ def unpack_message(data, hmac_key=None, header=None, no_retcode=False):
         retcode_len = struct.calcsize(MESSAGE_RETCODE_FMT)
         if no_retcode is False:
             pass
-        elif no_retcode is None and payload[0] != b'{' and payload[retcode_len] == b'{':
+        elif no_retcode is None and payload[0:1] != b'{' and payload[retcode_len:retcode_len+1] == b'{':
             retcode_len = struct.calcsize(MESSAGE_RETCODE_FMT)
         else:
             retcode_len = 0

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -228,7 +228,10 @@ class AESCipher(object):
         if Crypto:
             if iv:
                 if iv is True:
-                    iv = str(time.time() * 10)[:12].encode('utf8')
+                    if log.isEnabledFor( logging.DEBUG ):
+                        iv = b'0123456789ab'
+                    else:
+                        iv = str(time.time() * 10)[:12].encode('utf8')
                 cipher = AES.new(self.key, mode=AES.MODE_GCM, nonce=iv)
                 if header:
                     cipher.update(header)

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -1297,7 +1297,7 @@ class XenonDevice(object):
             )
 
         self.cipher = None
-        msg = TuyaMessage(self.seqno, msg.cmd, 0, payload, 0, True)
+        msg = TuyaMessage(self.seqno, msg.cmd, 0, payload, 0, True, PREFIX_55AA_VALUE, False)
         self.seqno += 1  # increase message sequence number
         buffer = pack_message(msg,hmac_key=hmac_key)
         log.debug("payload encrypted=%r",binascii.hexlify(buffer))

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -1336,6 +1336,7 @@ def devices(verbose=False, scantime=None, color=True, poll=True, forcescan=False
 
             data, addr = sock.recvfrom(4048)
             ip = addr[0]
+            result = b''
             try:
                 try:
                     result = tinytuya.decrypt_udp( data )
@@ -1344,8 +1345,9 @@ def devices(verbose=False, scantime=None, color=True, poll=True, forcescan=False
                 result = json.loads(result)
                 log.debug("Received valid UDP packet: %r", result)
             except:
+                #traceback.print_exc()
                 if verbose:
-                    print(term.alertdim + "*  Unexpected payload from %r to port %r:%s %r\n" % (ip, tgt_port, term.normal, data))
+                    print(term.alertdim + "*  Unexpected payload from %r to port %r:%s %r (%r)\n" % (ip, tgt_port, term.normal, result, data))
                 log.debug("Invalid UDP Packet from %r port %r - %r", ip, tgt_port, data)
                 continue
 


### PR DESCRIPTION
It currently only works with PyCryptodome.  We can probably make it work with pyaes as well, I just haven't had time to research it yet.

Due to it encrypting the retcode I ended up moving the encryption/decryption into pack_message()/unpack_message() so it can populate TuyaMessage.retcode.  TuyaMessage was also extended to add .prefix (which is required no matter which way we go) and .iv (not required but I thought it might be useful).  The new 6699 format has an additional 16-bit field that I'm not currently packing into TuyaMessage as I have no idea what to call it.