### PR TITLE
Normalize snapshot.json fields and add "version" to devices.json

### DIFF
--- a/examples/devices.py
+++ b/examples/devices.py
@@ -98,8 +98,4 @@ for i in tuyadevices:
 # for loop
 
 # Save polling data snapshot.json
-current = {'timestamp' : time.time(), 'devices' : polling}
-output = json.dumps(current, indent=4) 
-print(bold + "\n>> " + normal + "Saving device snapshot data to " + SNAPSHOTFILE)
-with open(SNAPSHOTFILE, "w") as outfile:
-    outfile.write(output)
+tinytuya.scanner.save_snapshotfile( SNAPSHOTFILE, polling, None )

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -205,14 +205,17 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
         iplist = {}
         found = 0
         for itm in result:
-            if 'gwId' in itm and itm['gwId'] and 'ip' in itm and itm['ip']:
+            if 'gwId' in itm and itm['gwId']:
                 gwid = itm['gwId']
-                iplist[gwid] = itm['ip']
+                ip = itm['ip'] if 'ip' in itm and itm['ip'] else ''
+                ver = itm['version'] if 'version' in itm and itm['version'] else ''
+                iplist[gwid] = (ip, ver)
         for k in range( len(tuyadevices) ):
             gwid = tuyadevices[k]['id']
             if gwid in iplist:
-                tuyadevices[k]['ip'] = iplist[gwid]
-                found += 1
+                tuyadevices[k]['ip'] = iplist[gwid][0]
+                tuyadevices[k]['version'] = iplist[gwid][1]
+                if iplist[gwid][0]: found += 1
         if found:
             # re-write devices.json now that we have IP addresses
             output = json.dumps(tuyadevices, indent=4)


### PR DESCRIPTION
Snapshot saving should now be done through tinytuya.scanner.save_snapshotfile().  This function normalizes all the field names and value types before saving.  To load, call tinytuya.scanner.load_snapshotfile() to convert back.

I went with "ver" and "id" in snapshot.json as that's what older versions used.  When loaded, "ver" gets replaced with "version" and "id" is copied into "gwId"