### PR TITLE
Remove bulb attribute conditional block #265 - Stage for v1.10.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # RELEASE NOTES
 
+## v1.10.1 - Bug Fix for BulbDevice and Zigbee Devices
+
+* PyPI 1.10.1
+* Fix _process_message() missing parameters discovered via issue https://github.com/jasonacox/tinytuya/issues/266 by @jasonacox in https://github.com/jasonacox/tinytuya/pull/267
+* Removed bulb attribute conditional blocking in BulbDevice set_colour(), set_hsv() and set_colourtemp() as some devices do not correctly report capabilities. Conditional provides debug warning message instead by @jasonacox in https://github.com/jasonacox/tinytuya/issues/265
+
 ## v1.10.0 - Tuya Protocol v3.5 Device Support / Scanner Rewrite
 
 * PyPI 1.10.0

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -312,9 +312,8 @@ class BulbDevice(Device):
             nowait(bool): True to send without waiting for response.
         """
         if not self.has_colour:
-            return error_json(
-                ERR_FUNCTION, "set_colour: Device does not support color."
-            )
+            log.debug("set_colour: Device does not appear to support color.")
+            # return error_json(ERR_FUNCTION, "set_colour: Device does not support color.")
         if not 0 <= r <= 255:
             return error_json(
                 ERR_RANGE,
@@ -354,22 +353,21 @@ class BulbDevice(Device):
             nowait(bool): True to send without waiting for response.
         """
         if not self.has_colour:
-            return error_json(
-                ERR_FUNCTION, "set_colour: Device does not support color."
-            )
+            log.debug("set_hsv: Device does not appear to support color.")
+            # return error_json(ERR_FUNCTION, "set_hsv: Device does not support color.")
         if not 0 <= h <= 1.0:
             return error_json(
-                ERR_RANGE, "set_colour: The value for Hue needs to be between 0 and 1."
+                ERR_RANGE, "set_hsv: The value for Hue needs to be between 0 and 1."
             )
         if not 0 <= s <= 1.0:
             return error_json(
                 ERR_RANGE,
-                "set_colour: The value for Saturation needs to be between 0 and 1.",
+                "set_hsv: The value for Saturation needs to be between 0 and 1.",
             )
         if not 0 <= v <= 1.0:
             return error_json(
                 ERR_RANGE,
-                "set_colour: The value for Value needs to be between 0 and 1.",
+                "set_hsv: The value for Value needs to be between 0 and 1.",
             )
 
         (r, g, b) = colorsys.hsv_to_rgb(h, s, v)
@@ -521,9 +519,8 @@ class BulbDevice(Device):
             if state["mode"] == "white":
                 # for white mode use DPS for brightness
                 if not self.has_brightness:
-                    return error_json(
-                        ERR_FUNCTION, "set_colour: Device does not support brightness."
-                    )
+                    log.debug("set_brightness: Device does not appear to support brightness.")
+                    # return error_json(ERR_FUNCTION, "set_brightness: Device does not support brightness.")
                 payload = self.generate_payload(
                     CONTROL, {self.DPS_INDEX_BRIGHTNESS[self.bulb_type]: brightness}
                 )
@@ -572,9 +569,8 @@ class BulbDevice(Device):
             nowait(bool): True to send without waiting for response.
         """
         if not self.has_colourtemp:
-            return error_json(
-                ERR_FUNCTION, "set_colourtemp: Device does not support colortemp."
-            )
+            log.debug("set_colourtemp: Device does not appear to support colortemp.")
+            # return error_json(ERR_FUNCTION, "set_colourtemp: Device does not support colortemp.")
         if self.bulb_type == "A" and not 0 <= colourtemp <= 255:
             return error_json(
                 ERR_RANGE,

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -83,7 +83,7 @@ except ImportError:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 10, 0)
+version_tuple = (1, 10, 1)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 


### PR DESCRIPTION
Removed bulb attribute conditional blocking in BulbDevice set_colour(), set_hsv() and set_colourtemp() as some devices do not correctly report capabilities. Conditional provides debug warning message instead https://github.com/jasonacox/tinytuya/issues/265

Stage for v1.10.1.