### PR TITLE
Add Cloud IR example, update docu, and allow an optional initial token to Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Functions:
     set_status(on, switch=1, nowait)   # Control status of the device to 'on' or 'off' (bool)
                                        # nowait (default False) True to send without waiting for response
     set_value(index, value, nowait)    # Send and set value of any DPS/index on device.
+    set_multiple_values(index_value_dict, nowait)
+                                       # Set multiple values with a single request
+				       # Note: Some devices do not like this!
     heartbeat(nowait)                  # Send heartbeat to device
     updatedps(index=[1], nowait)       # Send updatedps command to device to refresh DPS values
     turn_on(switch=1, nowait)          # Turn on device / switch #

--- a/examples/cloud_ir.py
+++ b/examples/cloud_ir.py
@@ -1,0 +1,86 @@
+# TinyTuya Example
+# -*- coding: utf-8 -*-
+"""
+ TinyTuya - Tuya Cloud IR Functions
+
+ This example uses the Tinytuya Cloud class and functions
+ to send IR blaster commands
+
+ Author: uzlonewolf
+ For more information see https://github.com/jasonacox/tinytuya
+
+""" 
+import tinytuya
+import colorsys
+import time
+import json
+
+#tinytuya.set_debug()
+
+# Set this to the actual blaster device, not a virtual remote
+device_id = DEVICEID
+
+# Connect to Tuya Cloud - uses tinytuya.json
+c = tinytuya.Cloud()
+
+
+
+
+# Raw IR commands can be sent directly
+ir_cmd = {
+    "control":"send_ir",
+    "head":"010ed20000000000040015004000ad0730",
+    "key1":"002$$0020E0E0E01F@%",
+    "type":0,
+    "delay":300
+}
+
+cloud_cmd = {
+    "commands": [
+        {
+            "code": "ir_send",
+            "value": json.dumps(ir_cmd)
+        },
+    ]
+}
+
+print('Send Raw result:')
+res = c.sendcommand(device_id, cloud_cmd)
+print( json.dumps(res, indent=2) )
+
+
+
+
+# Keys from a virtual remote can also be sent
+#
+# See https://developer.tuya.com/en/docs/cloud/ir-control-hub-open-service?id=Kb3oe2mk8ya72
+#   for API documentation
+
+
+# First, get a listing of all programmed remotes
+print('List of remotes:')
+remote_list = c.cloudrequest( '/v2.0/infrareds/' + device_id + '/remotes' )
+print( json.dumps(remote_list, indent=2) )
+
+# Next, get a list of keys for a remote using remote_id from the list returned by the previous command
+print('List of keys on 1st remote:')
+remote_id = remote_list['result'][0]['remote_id'] # Grab the first remote for this example
+remote_key_list = c.cloudrequest( '/v2.0/infrareds/%s/remotes/%s/keys' % (device_id, remote_id) )
+print( json.dumps(remote_key_list, indent=2) )
+
+# Finally, send the 'Power' key
+post_data = {
+    "key": "OK", #"Power",
+    "category_id": remote_key_list['result']['category_id'],
+    "remote_index": remote_key_list['result']['remote_index']
+}
+print('Send key result:')
+res = c.cloudrequest( '/v2.0/infrareds/%s/remotes/%s/command' % (device_id, remote_id), post=post_data )
+print( json.dumps(res, indent=2) )
+
+
+
+# The actual value sent by the above key can be found by checking the device logs
+print('Device logs:')
+logs = c.getdevicelog(device_id, evtype='5', size=3, max_fetches=1)
+print( json.dumps(logs, indent=2) )

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -42,14 +42,12 @@ from .core import * # pylint: disable=W0401, W0614
 ########################################################
 
 class Cloud(object):
-    def __init__(self, apiRegion=None, apiKey=None, apiSecret=None, apiDeviceID=None, new_sign_algorithm=True):
+    def __init__(self, apiRegion=None, apiKey=None, apiSecret=None, apiDeviceID=None, new_sign_algorithm=True, initial_token=None):
         """
         Tuya Cloud IoT Platform Access
 
         Args:
-            dev_id (str): The device id.
-            address (str): The network address.
-            local_key (str, optional): The encryption key. Defaults to None.
+            initial_token: The auth token from a previous run.  It will be refreshed if it has expired
 
         Playload Construction - Header Data:
             Parameter 	  Type    Required	Description
@@ -81,7 +79,7 @@ class Cloud(object):
         self.apiDeviceID = apiDeviceID
         self.urlhost = ''
         self.uid = None     # Tuya Cloud User ID
-        self.token = None
+        self.token = initial_token
         self.error = None
         self.new_sign_algorithm = new_sign_algorithm
         self.server_time_offset = 0
@@ -105,8 +103,10 @@ class Cloud(object):
                 raise TypeError('Tuya Cloud Key and Secret required') # pylint: disable=W0707
 
         self.setregion(apiRegion)
-        # Attempt to connect to cloud and get token
-        self._gettoken()
+
+        if not self.token:
+            # Attempt to connect to cloud and get token
+            self._gettoken()
 
     def setregion(self, apiRegion=None):
         # Set hostname based on apiRegion

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -466,6 +466,7 @@ class Cloud(object):
     def getdevicelog(self, deviceid=None, start=None, end=None, evtype=None, size=0, max_fetches=50, start_row_key=None, params=None):
         """
         Get the logs for a device.
+        https://developer.tuya.com/en/docs/cloud/0a30fc557f?id=Ka7kjybdo0jse
 
         Note: The cloud only returns logs for DPs in the "official" DPS list.
           If the device specifications are wrong then not all logs will be returned!
@@ -512,8 +513,17 @@ class Cloud(object):
         if not evtype:
             # get them all by default
             # 1 = device online, 7 = DP report
-            # https://developer.tuya.com/en/docs/cloud/0a30fc557f?id=Ka7kjybdo0jse
             evtype = '1,2,3,4,5,6,7,8,9,10'
+        elif type(evtype) == str:
+            pass
+        elif type(evtype) == bytes:
+            evtype = evtype.decode('utf8')
+        elif type(evtype) == int:
+            evtype = str(evtype)
+        elif type(evtype) == list or type(evtype) == tuple:
+            evtype = ','.join( [str(i) for i in evtype] )
+        else:
+            raise ValueError( "Unhandled 'evtype' type %s - %r" % (type(evtype), evtype) )
         want_size = size
         if not size:
             size = 100

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -26,6 +26,8 @@
     set_retry(retry=True)              # retry if response payload is truncated
     set_status(on, switch=1, nowait)   # Set status of switch to 'on' or 'off' (bool)
     set_value(index, value, nowait)    # Set int value of any index.
+    set_multiple_values(index_value_dict, nowait)
+                                       # Set multiple values with a single request
     heartbeat(nowait)                  # Send heartbeat to device
     updatedps(index=[1], nowait)       # Send updatedps command to device
     turn_on(switch=1, nowait)          # Turn on device / switch #


### PR DESCRIPTION
The 1-2 second delay every time I called tinytuya.Cloud() was annoying me, so I added an option to pass in an initial auth token.  The existing code should auto-regenerate it if it has expired however I have not tested this.

Documentation for `d.set_multiple_values()` has been added to close #275 

A new example for Cloud IR sending has been added based upon the example I posted in #283 