### PR TITLE
Rework Cloud device list fetching

### DIFF
--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -34,7 +34,6 @@ import hmac
 import json
 import time
 import requests
-from datetime import datetime
 
 from .core import * # pylint: disable=W0401, W0614
 
@@ -339,15 +338,8 @@ class Cloud(object):
                 else:
                     our_result[i] = result[i]
 
-        our_result['file'] = {
-            "description": "Full raw list of Tuya devices.",
-            "account": self.apiKey,
-            "date": datetime.now().isoformat(),
-            "fetches": fetches,
-            "last_row_key": last_row_key,
-            "total": total,
-            "tinytuya": version
-        }
+        our_result['fetches'] = fetches
+        our_result['total'] = total
 
         return our_result
 

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -119,7 +119,7 @@ DEVICEFILE = 'devices.json'
 RAWFILE = 'tuya-raw.json'
 SNAPSHOTFILE = 'snapshot.json'
 
-DEVICEFILE_SAVE_VALUES = ('category', 'product_name', 'product_id', 'biz_type', 'model', 'sub', 'icon', 'version', 'last_ip', 'uuid', 'node_id')
+DEVICEFILE_SAVE_VALUES = ('category', 'product_name', 'product_id', 'biz_type', 'model', 'sub', 'icon', 'version', 'last_ip', 'uuid', 'node_id', 'sn')
 
 # Tuya Command Types
 # Reference: https://github.com/tuya/tuya-iotos-embeded-sdk-wifi-ble-bk7231n/blob/master/sdk/include/lan_protocol.h

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -91,11 +91,12 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
     print('')
 
     if (config['apiKey'] != '' and config['apiSecret'] != '' and
-            config['apiRegion'] != '' and config['apiDeviceID'] != ''):
+            config['apiRegion'] != ''):
         needconfigs = False
+        apiDeviceID = '<None>' if not config['apiDeviceID'] else config['apiDeviceID']
         print("    " + subbold + "Existing settings:" + dim +
               "\n        API Key=%s \n        Secret=%s\n        DeviceID=%s\n        Region=%s" %
-              (config['apiKey'], config['apiSecret'], config['apiDeviceID'],
+              (config['apiKey'], config['apiSecret'], apiDeviceID,
                config['apiRegion']))
         print('')
         answer = input(subbold + '    Use existing credentials ' +
@@ -111,7 +112,7 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
         config['apiSecret'] = input(subbold + "    Enter " + bold + "API Secret" + subbold +
                                     " from tuya.com: " + normal)
         config['apiDeviceID'] = input(subbold +
-                                      "    Enter " + bold + "any Device ID" + subbold +
+                                      "    (Optional) Enter " + bold + "any Device ID" + subbold +
                                       " currently registered in Tuya App (used to pull full list): " + normal)
         # TO DO - Determine apiRegion based on Device - for now, ask
         print("\n      " + subbold + "Region List" + dim +

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -181,6 +181,8 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
     if not nocloud:
         # Save raw TuyaPlatform data to tuya-raw.json
         print(bold + "\n>> " + normal + "Saving raw TuyaPlatform response to " + RAWFILE)
+        if 'file' in json_data:
+            json_data['file']['name'] = RAWFILE
         try:
             with open(RAWFILE, "w") as outfile:
                 outfile.write(json.dumps(json_data, indent=4))

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -25,6 +25,7 @@ Credits
 from __future__ import print_function
 import json
 from colorama import init
+from datetime import datetime
 import tinytuya
 
 # Backward compatibility for python2
@@ -181,8 +182,13 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
     if not nocloud:
         # Save raw TuyaPlatform data to tuya-raw.json
         print(bold + "\n>> " + normal + "Saving raw TuyaPlatform response to " + RAWFILE)
-        if 'file' in json_data:
-            json_data['file']['name'] = RAWFILE
+        json_data['file'] = {
+            'name': RAWFILE,
+            'description': 'Full raw list of Tuya devices.',
+            'account': cloud.apiKey,
+            'date': datetime.now().isoformat(),
+            'tinytuya': tinytuya.version
+        }
         try:
             with open(RAWFILE, "w") as outfile:
                 outfile.write(json.dumps(json_data, indent=4))


### PR DESCRIPTION
Creating as a draft to get the conversation started.

Due to a number of reasons, I now have 2 App accounts: the one I use, and a 2nd I give out to people.  The way the device list is currently fetched only returns the devices tied to the one account the provided Device ID is associated with.  I went hunting and discovered https://developer.tuya.com/en/docs/cloud/fc19523d18?id=Kakr4p8nq5xsc which returns all devices for all accounts.  The only downside is the list is stored in `result->devices` instead of `result` directly.  It also needs to be looped if there are more than `size` devices, which is a problem I will soon run into as I'll be surpassing 100 devices later today or tomorrow (mainly thanks to $dayjob getting enamored with putting smart bulbs into track lights).  On the upside it means people no longer need to find an initial Device ID when configuring tinytuya.

My main question is about handling the slightly different return format.  I currently have it reformatting the list into the original format to keep from breaking anything which parses `tuya-raw.json`, but that causes it to drop some metadata and is no longer a true "this is exactly what we got from the server."

Old format:
```json
{
    "result": [
        {
            "active_time": 1677110164,
            "biz_type": 18,
            "category": "tdq",
            "create_time": 1677110164,
...
            "update_time": 1652097381,
        }
    ],
    "success": true,
    "t": 1677263715070,
    "tid": "faxxxxxxxxxxxxxxxxxxxxxxee"
}
```

New format:
```json
{
  "result": {
    "devices": [
      {
        "active_time": 1677110164,
        "biz_type": 18,
        "category": "tdq",
        "create_time": 1677110164,
...
	"update_time": 1652097381,
      }
    ],
    "has_more": false,
    "last_row_key": "08xxxxxxxxxxxxxxxxxxxxC8",
    "total": 98
  },
  "success": true,
  "t": 1677262499887,
  "tid": "26xxxxxxxxxxxxxxxxxxxxxxxxb2"
}
```

Should I write the new format to tuya-raw.json, or keep doing what I'm currently doing and reformatting it into the old format?  With how I'm going to need to loop for multiple cloud calls, should I go with my initial plan of merging the multiple device lists into a single list or should I create a new list and store each call separately?