### PR TITLE
Tighten up parent device detection in the Wizard

### DIFF
--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -158,16 +158,22 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
         tuyadevices = cloud.filter_devices( json_data['result'] )
 
     for dev in tuyadevices:
-        if 'sub' in dev and dev['sub'] and 'id' in dev and 'key' in dev and dev['key']:
-            found = False
-            for parent in tuyadevices:
-                if 'id' not in parent or parent['id'] == dev['id']:
-                    continue
-                # the local key seems to be the only way of identifying the parent device
-                if 'key' in parent and parent['key'] and dev['key'] == parent['key'] and ( 'sub' not in parent or not parent['sub']):
-                    found = parent
-                    break
-            dev['parent'] = found['id'] if found else ''
+        if 'sub' in dev and dev['sub']:
+            if 'parent' not in dev:
+                dev['parent'] = ''
+            if 'key' in dev and dev['key']:
+                if 'id' not in dev:
+                    dev['id'] = ''
+                found = False
+                for parent in tuyadevices:
+                    if 'id' not in parent or parent['id'] == dev['id']:
+                        continue
+                    # the local key seems to be the only way of identifying the parent device
+                    if 'key' in parent and parent['key'] and dev['key'] == parent['key'] and ( 'sub' not in parent or not parent['sub']):
+                        found = parent
+                        break
+                if found:
+                    dev['parent'] = found['id']
 
     # Display device list
     print("\n\n" + bold + "Device Listing\n" + dim)

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -158,11 +158,13 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
         tuyadevices = cloud.filter_devices( json_data['result'] )
 
     for dev in tuyadevices:
-        if 'sub' in dev and dev['sub'] and 'key' in dev:
+        if 'sub' in dev and dev['sub'] and 'id' in dev and 'key' in dev and dev['key']:
             found = False
             for parent in tuyadevices:
+                if 'id' not in parent or parent['id'] == dev['id']:
+                    continue
                 # the local key seems to be the only way of identifying the parent device
-                if 'key' in parent and 'id' in parent and dev['key'] == parent['key']:
+                if 'key' in parent and parent['key'] and dev['key'] == parent['key'] and ( 'sub' not in parent or not parent['sub']):
                     found = parent
                     break
             if found:

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -157,6 +157,7 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
         # Filter to only Name, ID and Key, IP and mac-address
         tuyadevices = cloud.filter_devices( json_data['result'] )
 
+    # Try to create parent-child linkage on gateway controlled devices (with sub key)
     for dev in tuyadevices:
         if 'sub' in dev and dev['sub']:
             if 'parent' not in dev:
@@ -166,9 +167,10 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
                     dev['id'] = ''
                 found = False
                 for parent in tuyadevices:
+                    # loop through all devices again to see if there is a matching local key
                     if 'id' not in parent or parent['id'] == dev['id']:
                         continue
-                    # the local key seems to be the only way of identifying the parent device
+                    # check for matching keys and if device is missing sub key - assume we found parent
                     if 'key' in parent and parent['key'] and dev['key'] == parent['key'] and ( 'sub' not in parent or not parent['sub']):
                         found = parent
                         break

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -167,8 +167,7 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False):
                 if 'key' in parent and parent['key'] and dev['key'] == parent['key'] and ( 'sub' not in parent or not parent['sub']):
                     found = parent
                     break
-            if found:
-                dev['parent'] = found['id']
+            dev['parent'] = found['id'] if found else ''
 
     # Display device list
     print("\n\n" + bold + "Device Listing\n" + dim)


### PR DESCRIPTION
Not all devices have local keys as shown by #292, and this broke parent device detection.  This PR tightens up parent detection to avoid devices without local keys.  Between this PR and #289 I'm going to go ahead and say closes #292.