### PR TITLE
Rework logging

### DIFF
--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -242,7 +242,7 @@ class BulbDevice(Device):
         else:
             # response has no dps
             self.bulb_type = "B"
-        log.debug("bulb type set to %s", self.bulb_type)
+        self.log.debug("bulb type set to %s", self.bulb_type)
 
     def turn_on(self, switch=0, nowait=False):
         """Turn the device on"""
@@ -312,7 +312,7 @@ class BulbDevice(Device):
             nowait(bool): True to send without waiting for response.
         """
         if not self.has_colour:
-            log.debug("set_colour: Device does not appear to support color.")
+            self.log.debug("set_colour: Device does not appear to support color.")
             # return error_json(ERR_FUNCTION, "set_colour: Device does not support color.")
         if not 0 <= r <= 255:
             return error_json(
@@ -353,7 +353,7 @@ class BulbDevice(Device):
             nowait(bool): True to send without waiting for response.
         """
         if not self.has_colour:
-            log.debug("set_hsv: Device does not appear to support color.")
+            self.log.debug("set_hsv: Device does not appear to support color.")
             # return error_json(ERR_FUNCTION, "set_hsv: Device does not support color.")
         if not 0 <= h <= 1.0:
             return error_json(
@@ -519,7 +519,7 @@ class BulbDevice(Device):
             if state["mode"] == "white":
                 # for white mode use DPS for brightness
                 if not self.has_brightness:
-                    log.debug("set_brightness: Device does not appear to support brightness.")
+                    self.log.debug("set_brightness: Device does not appear to support brightness.")
                     # return error_json(ERR_FUNCTION, "set_brightness: Device does not support brightness.")
                 payload = self.generate_payload(
                     CONTROL, {self.DPS_INDEX_BRIGHTNESS[self.bulb_type]: brightness}
@@ -569,7 +569,7 @@ class BulbDevice(Device):
             nowait(bool): True to send without waiting for response.
         """
         if not self.has_colourtemp:
-            log.debug("set_colourtemp: Device does not appear to support colortemp.")
+            self.log.debug("set_colourtemp: Device does not appear to support colortemp.")
             # return error_json(ERR_FUNCTION, "set_colourtemp: Device does not support colortemp.")
         if self.bulb_type == "A" and not 0 <= colourtemp <= 255:
             return error_json(

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -84,6 +84,7 @@ class Cloud(object):
         self.new_sign_algorithm = new_sign_algorithm
         self.server_time_offset = 0
         self.use_old_device_list = False
+        self.log = log.getChild('Cloud')
 
         if (not apiKey) or (not apiSecret):
             try:
@@ -205,11 +206,11 @@ class Cloud(object):
         # Send Request to Cloud and Get Response
         if action == 'GET':
             response = requests.get(url, headers=headers)
-            log.debug(
+            self.log.debug(
                 "GET: URL=%s HEADERS=%s response code=%d text=%s token=%s", url, headers, response.status_code, response.text, self.token
             )
         else:
-            log.debug(
+            self.log.debug(
                 "POST: URL=%s HEADERS=%s DATA=%s", url, headers, body,
             )
             response = requests.post(url, headers=headers, data=body)
@@ -217,12 +218,12 @@ class Cloud(object):
         # Check to see if token is expired
         if "token invalid" in response.text:
             if recursive is True:
-                log.debug("Failed 2nd attempt to renew token - Aborting")
+                self.log.debug("Failed 2nd attempt to renew token - Aborting")
                 return None
-            log.debug("Token Expired - Try to renew")
+            self.log.debug("Token Expired - Try to renew")
             self._gettoken()
             if not self.token:
-                log.debug("Failed to renew token")
+                self.log.debug("Failed to renew token")
                 return None
             else:
                 return self._tuyaplatform(uri, action, post, ver, True)
@@ -258,7 +259,7 @@ class Cloud(object):
             # round it to 2 minutes to try and factor out any processing delays
             self.server_time_offset = round( ((response_dict['t'] / 1000.0) - time.time()) / 120 )
             self.server_time_offset *= 120
-            log.debug("server_time_offset: %r", self.server_time_offset)
+            self.log.debug("server_time_offset: %r", self.server_time_offset)
 
         self.token = response_dict['result']['access_token']
         return self.token
@@ -280,7 +281,7 @@ class Cloud(object):
                 response_dict['code'] = -1
             if 'msg' not in response_dict:
                 response_dict['msg'] = 'Unknown Error'
-            log.debug(
+            self.log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
             return error_json(
@@ -322,10 +323,10 @@ class Cloud(object):
             has_more = False
 
             if type(result) == dict:
-                log.debug( 'Cloud response:' )
-                log.debug( json.dumps( result, indent=2 ) )
+                self.log.debug( 'Cloud response:' )
+                self.log.debug( json.dumps( result, indent=2 ) )
             else:
-                log.debug( 'Cloud response: %r', result )
+                self.log.debug( 'Cloud response: %r', result )
 
             # format it the same as before, basically just moves result->devices into result
             for i in result:
@@ -381,7 +382,7 @@ class Cloud(object):
             # returns id, mac, uuid (and sn if available)
             uri = 'devices/factory-infos?device_ids=%s' % (",".join(devices[:50]))
             result = self._tuyaplatform(uri)
-            log.debug( json.dumps( result, indent=2 ) )
+            self.log.debug( json.dumps( result, indent=2 ) )
             if 'result' in result:
                 for dev in result['result']:
                     if 'id' in dev:
@@ -438,7 +439,7 @@ class Cloud(object):
         response_dict = self._tuyaplatform(uri)
 
         if not response_dict['success']:
-            log.debug(
+            self.log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
         return response_dict
@@ -476,7 +477,7 @@ class Cloud(object):
         response_dict = self._tuyaplatform(uri, ver='v1.1')
 
         if not response_dict['success']:
-            log.debug(
+            self.log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
         return response_dict
@@ -496,7 +497,7 @@ class Cloud(object):
         response_dict = self._tuyaplatform(uri,action='POST',post=commands)
 
         if not response_dict['success']:
-            log.debug(
+            self.log.debug(
                 "Error from Tuya Cloud: %r", response_dict['msg'],
             )
         return response_dict
@@ -516,7 +517,7 @@ class Cloud(object):
         response_dict = self._tuyaplatform(uri, ver='v1.0')
 
         if not response_dict['success']:
-            log.debug("Error from Tuya Cloud: %r", response_dict['msg'])
+            self.log.debug("Error from Tuya Cloud: %r", response_dict['msg'])
         return(response_dict["result"]["online"])
 
     def getdevicelog(self, deviceid=None, start=None, end=None, evtype=None, size=0, max_fetches=50, start_row_key=None, params=None):

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -16,8 +16,6 @@
 # Modules
 import sys
 import tinytuya
-from . import wizard
-from . import scanner
 
 retries = None
 state = 0
@@ -27,6 +25,7 @@ force_list = []
 last_force = False
 broadcast_listen = True
 assume_yes = False
+debug = False
 
 for i in sys.argv:
     if i==sys.argv[0]:
@@ -52,7 +51,7 @@ for i in sys.argv:
     elif i.lower() == "-yes" or i.lower() == "-y":
         assume_yes = True
     elif i.lower() == "-debug" or i.lower() == "-d":
-        tinytuya.set_debug(True)
+        debug = True
     elif last_force and len(i) > 6:
         this_force = True
         force_list.append( i )
@@ -66,6 +65,18 @@ for i in sys.argv:
 
 if force and len(force_list) > 0:
     force = force_list
+
+tinytuya.set_debug(debug, color)
+#if debug:
+#    if color:
+#        logging.basicConfig( format="\x1b[0m\x1b[31;1m%(levelname)s:\x1b[22m%(name)s:\x1b[39;2m%(message)s\x1b[0m", level=logging.DEBUG )
+#    else:
+#        logging.basicConfig( level=logging.DEBUG )
+
+if state == 1:
+    from . import wizard
+else:
+    from . import scanner
 
 # State 0 = Run Network Scan
 if state == 0:

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -86,7 +86,7 @@ FSCAN_FINAL_POLL = 100
 
 
 # Logging
-log = logging.getLogger(__name__)
+log = tinytuya.log.getChild('scanner')
 
 # Helper Functions
 def getmyIP():
@@ -524,7 +524,7 @@ class ForceScannedDevice(DeviceDetect):
             if msg.cmd == tinytuya.SESS_KEY_NEG_RESP:
                 if not self.v34_negotiate_sess_key_step_2( msg ):
                     #if self.debug:
-                    print('odata:', odata)
+                    print('ForceScannedDevice: raw packet:', odata)
                     self.timeout()
                     return
                 self.read = False
@@ -840,7 +840,7 @@ class PollDevice(DeviceDetect):
 
             if msg.cmd == tinytuya.SESS_KEY_NEG_RESP:
                 if not self.v34_negotiate_sess_key_step_2( msg ):
-                    print('odata:', odata)
+                    print('PollDevice: raw packet:', odata)
                     self.timeout()
                     return
                 self.read = False


### PR DESCRIPTION
I recently discovered another issue with having tons of devices.  Like I mentioned in https://github.com/jasonacox/tinytuya/discussions/208#discussioncomment-4082687, I'm dumping a bunch of device sockets into select.select() just like the scanner does.  Do you know what happens if you turn debug on and then poll the status of 52 devices simultaneously?  It's... not pretty.  So, I reworked the logging.  Log messages now include the "name" of the source, which for devices is i.e. "tinytuya.OutletDevice.eb1######s".  Initially I removed the red coloring of the text from the message, but then decided it was probably there for a reason and put it back.  I did keep the device ID in cyan though.  Red removed:
![Screenshot from 2023-03-13 20-14-56 cropped](https://user-images.githubusercontent.com/16113541/224949821-295ec19e-bbe1-4f82-bbc8-96b09da381c4.png)

Red put back:
![Screenshot from 2023-03-13 23-55-49 cropped](https://user-images.githubusercontent.com/16113541/224949814-1759b670-ad3d-4064-aef5-b48b87d3ffdf.png)

When I added the per-device debug toggle I also made its color selection independent (default is to match the global).  I didn't intend it to be this way, but it worked out really well as it allows things like:
![Screenshot from 2023-03-14 01-42-14 cropped](https://user-images.githubusercontent.com/16113541/224949803-6249cdd1-50f7-4494-93f3-d285731918d5.png)

Anyway, I have this as a draft as it needs a \*lot\* more testing.  I've only verified it works for basic functions.