### PR TITLE
improve sendcommand

### DIFF
--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -481,7 +481,7 @@ class Cloud(object):
             )
         return response_dict
 
-    def sendcommand(self, deviceid=None, commands=None):
+    def sendcommand(self, deviceid=None, commands=None, uri='iot-03/devices/'):
         """
         Send a command to the device
         """
@@ -492,7 +492,7 @@ class Cloud(object):
                 ERR_PARAMS,
                 "Missing DeviceID and/or Command Parameters"
             )
-        uri = 'iot-03/devices/%s/commands' % (deviceid)
+        uri += '%s/commands' % (deviceid)
         response_dict = self._tuyaplatform(uri,action='POST',post=commands)
 
         if not response_dict['success']:


### PR DESCRIPTION
Hello, I have an infrared tuya device. I tryied to control my TV with tinytuya, it did not work (smart life app is working ofc). So I look into https://iot.tuya.com/cloud/ > my app > devices > debug device > device debugging and look the API commands send by the javascript .

All of that for this little change with URI=iot-03/devices/DEVID/commands if does not work, with URI=devices/DEVID/commands it works.

I hope it will help some other persons. 