### PR TITLE
Fix fan_run_time typo in Contrib/ThermostatDevice

### DIFF
--- a/tinytuya/Contrib/ThermostatDevice.py
+++ b/tinytuya/Contrib/ThermostatDevice.py
@@ -347,7 +347,7 @@ class ThermostatDevice(Device):
         return self.setValue( 'hold', hold )
 
     def setFanRuntime( self, rt ):
-        return self.setValue( 'fan_runtime', int(rt) )
+        return self.setValue( 'fan_run_time', int(rt) )
 
     def setValue( self, key, val ):
         dps, val = self.parseValue( key, val )


### PR DESCRIPTION
This is needed to update the fan runtime during fan cycle mode