### PR TITLE
Remove requirement for PyCryptodome in scanner (allows pyaes when no …

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ TinyTuya has a built-in setup Wizard that uses the Tuya IoT Cloud Platform to ge
 
 1. PAIR - Download the *Smart Life App* or *Tuya Smart App*, available for [iPhone](https://itunes.apple.com/us/app/smart-life-smart-living/id1115101477?mt=8) or [Android](https://play.google.com/store/apps/details?id=com.tuya.smartlife&hl=en). Pair all of your Tuya devices (this is important as you cannot access a device that has not been paired).
 
-2. SCAN - Run the TinyTuya scan to get a list of Tuya devices on your network. It will show device *Address*, *Device ID* and *Version* number (3.1 or 3.3):
+2. SCAN (Optional) - Run the TinyTuya scan to get a list of Tuya devices on your network. It will show device *Address*, *Device ID* and *Version* number (3.x):
     ```bash
     python -m tinytuya scan
     ```

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -1812,17 +1812,14 @@ class Device(XenonDevice):
 def pad(s):
     return s + (16 - len(s) % 16) * chr(16 - len(s) % 16)
 
-
 def unpad(s):
     return s[: -ord(s[len(s) - 1 :])]
 
-
 def encrypt(msg, key):
-    return AES.new(key, AES.MODE_ECB).encrypt(pad(msg).encode())
-
+    return AESCipher( key ).encrypt( msg, use_base64=False, pad=True )
 
 def decrypt(msg, key):
-    return unpad(AES.new(key, AES.MODE_ECB).decrypt(msg)).decode()
+    return AESCipher( key ).decrypt( msg, use_base64=False, decode_text=True )
 
 #def decrypt_gcm(msg, key):
 #    nonce = msg[:12]


### PR DESCRIPTION
…devices are v3.5+)  Also has a slight tweak to README.md.

Mentioned in #322 