### PR TITLE
Fix KeyError: 'has_more'

### DIFF
--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -376,8 +376,9 @@ class Cloud(object):
 
                     if 'total' in result[i]: total = result[i]['total']
                     if 'last_row_key' in result[i]:
-                        has_more = result[i]['has_more']
                         query['last_row_key'] = result[i]['last_row_key']
+                    if 'has_more' in result[i]:
+                        has_more = result[i]['has_more']
                 else:
                     our_result[i] = result[i]
 


### PR DESCRIPTION
Trying to request cloud with just one device throwing me:

```
Traceback (most recent call last):
  File "F:\Development\Workspace Python\tuya-local-stuff\main.py", line 28, in <module>
    main()
  File "F:\Development\Workspace Python\tuya-local-stuff\main.py", line 11, in main
    devices = cloud.getdevices()
  File "F:\Development\Workspace Python\tuya-local-stuff\venv\lib\site-packages\tinytuya\Cloud.py", line 434, in getdevices
    json_data = self._get_all_devices()
  File "F:\Development\Workspace Python\tuya-local-stuff\venv\lib\site-packages\tinytuya\Cloud.py", line 381, in _get_all_devices
    has_more = result[i]['has_more']
KeyError: 'has_more'
```

So I have added check if the key 'has_more' is in the result.