### PR TITLE
fix: call status() reset device

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## v1.12.7 - Status Bug Fix
+
+* PyPI 1.12.7
+* Fix bug in `detect_available_dps()` to resolve issue where `status()` call for smartbulbs would randomly cause devices to turn off by @xgustavoh in https://github.com/jasonacox/tinytuya/pull/345
+
 ## v1.12.6 - Minor Fixes
 
 * PyPI 1.12.6

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -87,7 +87,7 @@ except ImportError:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 12, 6)
+version_tuple = (1, 12, 7)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -1452,6 +1452,7 @@ class XenonDevice(object):
                 log.exception("Failed to get status: %s", ex)
                 raise
             if data is not None and "dps" in data:
+                data["dps"] = {k: None for k in data["dps"]}
                 self.dps_cache.update(data["dps"])
 
             if self.dev_type == "default":

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -1452,8 +1452,8 @@ class XenonDevice(object):
                 log.exception("Failed to get status: %s", ex)
                 raise
             if data is not None and "dps" in data:
-                data["dps"] = {k: None for k in data["dps"]}
-                self.dps_cache.update(data["dps"])
+                for k in data["dps"]:
+                    self.dps_cache[k] = None
 
             if self.dev_type == "default":
                 self.dps_to_request = self.dps_cache


### PR DESCRIPTION
Hello, first I would like to apologize for my English!

Recently I had a problem using a **Smart Bulb RGBCW7** in `version = 3.2`, that it was turning off or changing its status "randomly".

I noticed that whenever the `status()` function was executed, the bulb suffered a "reset" or "turning off".

After seeing the code, I noticed that the `dps_cache` was exactly to the value that the bulb was getting after the "reset".

When I set the `dps_to_request` values to `None, the problem didn't happen.

---

Adding this code in `def detect_available_dps(self):` solved my problem.
```python
data["dps"] = {k: None for k in data["dps"]}
```
