### PR TITLE
New Cloud functions to download DP Name mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ tuya-raw.json
 server/testproxy.sh
 server/uploadtest.sh
 devices.json.off
+mappings.json
 
 # packet captures
 *.pcap

--- a/DP_Mapping.md
+++ b/DP_Mapping.md
@@ -1,0 +1,29 @@
+# Tuya Cloud - Changing the Control Instruction Mode
+
+DPS to Name mappings are now downloaded with devices.json starting with TinyTuya v1.12.8.  If this DPS mapping is not correct then you will need to change the Control Instruction Mode to DP Instruction Mode.
+
+## How to get the full DPS mapping from Tuya Cloud.
+
+This how-to will show you how to activate “DP Instruction” mode for your Tuya devices when using Tuya Cloud to pull data.  This will result in getting the full list of DPS values and their properties for your devices.
+
+### Step 1 - Log in to your account on [iot.tuya.com](iot.tuya.com)
+
+### Step 2 - Navigate to "Cloud" -> "Development" then select your project.
+
+### Step 3 - Select "Devices" tab.
+
+<img width="756" alt="image" src="https://user-images.githubusercontent.com/836718/218344965-8f6cd378-d8fd-4e46-b35e-5e2ba2d3a9d4.png">
+
+### Step 4- Select the device types and click the the "pencil icon" to edit. 
+
+<img width="753" alt="image" src="https://user-images.githubusercontent.com/836718/218361449-f8c03832-8be3-4b25-b2cd-223dc2c89923.png">
+
+### Step 5 - Select the "DP Instruction" box and "Save Configuration"
+
+<img width="757" alt="image" src="https://user-images.githubusercontent.com/836718/218344985-41183289-ee0e-4484-aa8d-7489fc3a9f15.png">
+
+There doesn't appear to be a way to globally set "DP Instruction" for all device types.  You will need to select each device type and repeat the above step.
+
+### Step 6 - Use TinyTuya to access the full set of DPS
+
+After 12-24 hours, you should now be able to poll the Tuya Cloud using TinyTuya to get the full list of DPS properties and values.  Simply delete `devices.json` and re-run the Wizard.

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -478,9 +478,8 @@ class Cloud(object):
                 continue
             if (('icon' not in old) and ('icon' in dev)) or (include_map and ('mapping' not in old or old['mapping'] is None)):
                 # icon or mapping added
-                #changed_devices.append( dev )
-                #continue
-                pass
+                changed_devices.append( dev )
+                continue
             is_same = True
             for k in DEVICEFILE_SAVE_VALUES:
                 if k in dev and k != 'icon' and k != 'last_ip' and old[k] != dev[k]:

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -73,7 +73,7 @@ if state == 0:
 
 # State 1 = Run Setup Wizard
 if state == 1:
-    wizard.wizard(color=color, retries=retries, forcescan=force)
+    wizard.wizard(color=color, retries=retries, forcescan=force, quicklist=assume_yes)
 
 # State 2 = Snapshot Display and Scan
 if state == 2:

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -109,6 +109,7 @@ CONFIGFILE = 'tinytuya.json'
 DEVICEFILE = 'devices.json'
 RAWFILE = 'tuya-raw.json'
 SNAPSHOTFILE = 'snapshot.json'
+DPMAPPINGSFILE = 'mappings.json'
 
 DEVICEFILE_SAVE_VALUES = ('category', 'product_name', 'product_id', 'biz_type', 'model', 'sub', 'icon', 'version', 'last_ip', 'uuid', 'node_id', 'sn')
 
@@ -596,7 +597,7 @@ def device_info( dev_id ):
         with open(DEVICEFILE, 'r') as f:
             tuyadevices = json.load(f)
             log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
-            for	dev in tuyadevices:
+            for dev in tuyadevices:
                 if 'id' in dev and dev['id'] == dev_id:
                     log.debug("Device %r found in %s", dev_id, DEVICEFILE)
                     devinfo = dev
@@ -606,6 +607,30 @@ def device_info( dev_id ):
         pass
 
     return devinfo
+
+def load_mappings( mappingsfile=None ):
+    if not mappingsfile:
+        mappingsfile = DPMAPPINGSFILE
+    try:
+        with open( mappingsfile, 'r' ) as f:
+            mappings = json.load(f)
+            log.debug( 'loaded %d mappings from %s', len(mappings), mappingsfile )
+    except:
+        mappings = {}
+
+    return mappings
+
+def save_mappings( mappings, mappingsfile=None ):
+    if not mappingsfile:
+        mappingsfile = DPMAPPINGSFILE
+    try:
+        with open( mappingsfile, 'w' ) as f:
+            json.dump( mappings, f, indent=4 )
+            log.debug( 'saved %d mappings to %s', len(mappings), mappingsfile )
+    except:
+        return False
+
+    return True
 
 # Tuya Device Dictionary - Command and Payload Overrides
 #
@@ -1266,7 +1291,7 @@ class XenonDevice(object):
 
         return MessagePayload(SESS_KEY_NEG_START, self.local_nonce)
 
-    def	_negotiate_session_key_generate_step_3( self, rkey ):
+    def _negotiate_session_key_generate_step_3( self, rkey ):
         if not rkey or type(rkey) != TuyaMessage or len(rkey.payload) < 48:
             # error
             log.debug("session key negotiation failed on step 1")

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -26,6 +26,7 @@
     save_dp_mappings(mappings, mappingsfile=None)  # Saves the given mappings dict into DPMAPPINGSFILE (usually mappings.json)
     find_dp_mapping(product_id, mappingsfile=None) # Searches DPMAPPINGSFILE (usually mappings.json) for the given product_id, or DEVICEFILE for
                                                    #   the given device ID, and returns the mapping for that product/device
+    assign_dp_mappings(tuyadevices, mappingsfile=None)# Adds mappings to all the devices in the tuyadevices list (modified in place) using DPMAPPINGSFILE (usually mappings.json)
     decrypt_udp(msg)                               # Decrypts a UDP network broadcast packet
 
  Device Functions
@@ -651,7 +652,7 @@ def find_dp_mapping( product_id, mappingsfile=None ):
     Response:
         {dict} containing the mapping for the product id
     """
-    mappings = load_mappings( mappingsfile )
+    mappings = load_dp_mappings( mappingsfile )
     if not mappings:
         return None
 
@@ -668,6 +669,35 @@ def find_dp_mapping( product_id, mappingsfile=None ):
 
     # not found!
     return None
+
+def assign_dp_mappings( tuyadevices, mappingsfile=None ):
+    """ Adds mappings to all the devices in the tuyadevices list using DPMAPPINGSFILE (usually mappings.json)
+
+    Parameters:
+        tuyadevices = list of devices
+        mappingsfile = Optional mappings.json file to use, uses DPMAPPINGSFILE when empty
+
+    Response:
+        Nothing, modifies tuyadevices in place
+    """
+    mappings = load_dp_mappings( mappingsfile )
+    if (not mappings) or (not tuyadevices):
+        return None
+
+    for dev in tuyadevices:
+        try:
+            devid = dev['id']
+            productid = dev['product_id']
+        except:
+            # we need both the device id and the product id to download mappings!
+            log.debug( 'Cannot add DP mapping, no device id and/or product id: %r', dev )
+            continue
+
+        if productid in mappings:
+            dev['mapping'] = mappings[productid]
+        else:
+            log.debug( 'Device %s has no mapping!', devid )
+            dev['mapping'] = None
 
 def save_dp_mappings( mappings, mappingsfile=None ):
     """ Saves the given mappings dict into DPMAPPINGSFILE (usually mappings.json)

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -97,7 +97,7 @@ except ImportError:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 12, 7)
+version_tuple = (1, 12, 8)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -26,7 +26,8 @@
     save_dp_mappings(mappings, mappingsfile=None)  # Saves the given mappings dict into DPMAPPINGSFILE (usually mappings.json)
     find_dp_mapping(product_id, mappingsfile=None) # Searches DPMAPPINGSFILE (usually mappings.json) for the given product_id, or DEVICEFILE for
                                                    #   the given device ID, and returns the mapping for that product/device
-    assign_dp_mappings(tuyadevices, mappingsfile=None)# Adds mappings to all the devices in the tuyadevices list (modified in place) using DPMAPPINGSFILE (usually mappings.json)
+    assign_dp_mappings(tuyadevices, mappings=None)  # Adds mappings to all the devices in the tuyadevices list
+                                                    #  mappings is either a dict containing the mappings or the name of a file to load them from (uses DPMAPPINGSFILE if empty)
     decrypt_udp(msg)                               # Decrypts a UDP network broadcast packet
 
  Device Functions
@@ -670,17 +671,18 @@ def find_dp_mapping( product_id, mappingsfile=None ):
     # not found!
     return None
 
-def assign_dp_mappings( tuyadevices, mappingsfile=None ):
-    """ Adds mappings to all the devices in the tuyadevices list using DPMAPPINGSFILE (usually mappings.json)
+def assign_dp_mappings( tuyadevices, mappings=None ):
+    """ Adds mappings to all the devices in the tuyadevices list
 
     Parameters:
         tuyadevices = list of devices
-        mappingsfile = Optional mappings.json file to use, uses DPMAPPINGSFILE when empty
+        mappings = Optional, either a dict containing the mappings a string containing the mappings file to load.  Uses DPMAPPINGSFILE when empty
 
     Response:
         Nothing, modifies tuyadevices in place
     """
-    mappings = load_dp_mappings( mappingsfile )
+    if type(mappings) != dict:
+        mappings = load_dp_mappings( mappings )
     if (not mappings) or (not tuyadevices):
         return None
 

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -15,18 +15,18 @@
   * Device(XenonDevice) - Tuya Class for Devices
 
  Module Functions
-    set_debug(toggle, color)                    # Activate verbose debugging output
-    pack_message(msg, hmac_key=None)            # Packs a TuyaMessage() into a network packet, encrypting or adding a CRC if protocol requires
+    set_debug(toggle, color)                       # Activate verbose debugging output
+    pack_message(msg, hmac_key=None)               # Packs a TuyaMessage() into a network packet, encrypting or adding a CRC if protocol requires
     unpack_message(data, hmac_key=None, header=None, no_retcode=False)
-                                                # Unpacks a TuyaMessage() from a network packet, decrypting or checking the CRC if protocol requires
-    parse_header(data)                          # Unpacks just the header part of a message into a TuyaHeader()
-    find_device(dev_id=None, address=None)      # Scans network for Tuya devices with either ID = dev_id or IP = address
-    device_info(dev_id)                         # Searches DEVICEFILE (usually devices.json) for devices with ID = dev_id and returns just that device
-    load_mappings(mappingsfile=None)            # Loads DPMAPPINGSFILE (usually mappings.json) and returns the contents
-    find_mapping(product_id, mappingsfile=None) # Searches DPMAPPINGSFILE (usually mappings.json) for the given product_id, or DEVICEFILE for
-                                                #   the given device ID, and returns the mapping for that product/device
-    save_mappings(mappings, mappingsfile=None)  # Saves the given mappings dict into DPMAPPINGSFILE (usually mappings.json)
-    decrypt_udp(msg)                            # Decrypts a UDP network broadcast packet
+                                                   # Unpacks a TuyaMessage() from a network packet, decrypting or checking the CRC if protocol requires
+    parse_header(data)                             # Unpacks just the header part of a message into a TuyaHeader()
+    find_device(dev_id=None, address=None)         # Scans network for Tuya devices with either ID = dev_id or IP = address
+    device_info(dev_id)                            # Searches DEVICEFILE (usually devices.json) for devices with ID = dev_id and returns just that device
+    load_dp_mappings(mappingsfile=None)            # Loads DPMAPPINGSFILE (usually mappings.json) and returns the contents
+    save_dp_mappings(mappings, mappingsfile=None)  # Saves the given mappings dict into DPMAPPINGSFILE (usually mappings.json)
+    find_dp_mapping(product_id, mappingsfile=None) # Searches DPMAPPINGSFILE (usually mappings.json) for the given product_id, or DEVICEFILE for
+                                                   #   the given device ID, and returns the mapping for that product/device
+    decrypt_udp(msg)                               # Decrypts a UDP network broadcast packet
 
  Device Functions
     json = status()                    # returns json payload
@@ -621,7 +621,7 @@ def device_info( dev_id ):
 
     return devinfo
 
-def load_mappings( mappingsfile=None ):
+def load_dp_mappings( mappingsfile=None ):
     """Loads DPMAPPINGSFILE (usually mappings.json) and returns the contents
 
     Parameters:
@@ -641,7 +641,7 @@ def load_mappings( mappingsfile=None ):
 
     return mappings
 
-def find_mapping( product_id, mappingsfile=None ):
+def find_dp_mapping( product_id, mappingsfile=None ):
     """ Searches DPMAPPINGSFILE (usually mappings.json) for the given product_id, or DEVICEFILE for the given device ID, and returns the mapping for that product/device
 
     Parameters:
@@ -662,14 +662,14 @@ def find_mapping( product_id, mappingsfile=None ):
     # if not, see if it is a device in devices.json
     devinfo = device_info( product_id )
     if devinfo and 'product_id' in devinfo:
-        product_id = devinfo:['product_id']
+        product_id = devinfo['product_id']
         if product_id in mappings:
             return mappings[product_id]
 
     # not found!
     return None
 
-def save_mappings( mappings, mappingsfile=None ):
+def save_dp_mappings( mappings, mappingsfile=None ):
     """ Saves the given mappings dict into DPMAPPINGSFILE (usually mappings.json)
 
     Parameters:

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -237,6 +237,14 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
         except:
             print('\n\n' + bold + 'Unable to save raw file' + dim )
 
+    if (not nocloud) and (not quicklist):
+        answer = input(subbold + '\nDownload DP Name mappings? ' + normal + '(y/N): ')
+        if answer.lower().find('y') >= 0:
+            cloud.setmappings( tinytuya.load_mappings() )
+            mappings = cloud.getmappings( tuyadevices )
+            tinytuya.save_mappings( mappings )
+            print( bold + "\n>> " + normal + "Saved mappings for %d product IDs to %s" % (len(mappings), tinytuya.DPMAPPINGSFILE) )
+
     # Find out if we should poll all devices
     if quicklist:
         answer = 'n'

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -86,6 +86,13 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
         # First Time Setup
         pass
 
+    try:
+        # Load the old device list, if available
+        with open(DEVICEFILE, "r") as infile:
+            old_devices = json.load( infile )
+    except:
+        old_devices = {}
+
     (bold, subbold, normal, dim, alert, alertdim, cyan, red, yellow) = tinytuya.termcolor(color)
 
     print(bold + 'TinyTuya Setup Wizard' + dim + ' [%s]' % (tinytuya.version) + normal)
@@ -100,9 +107,7 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
               (config['apiKey'], config['apiSecret'], apiDeviceID,
                config['apiRegion']))
         print('')
-        if quicklist:
-            needconfigs = True
-        else:
+        if not quicklist:
             answer = input(subbold + '    Use existing credentials ' + normal + '(Y/n): ')
             if answer[0:1].lower() == 'n':
                 needconfigs = True
@@ -135,8 +140,7 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
         print(dim + json_object)
 
     if nocloud:
-        with open(DEVICEFILE, "r") as infile:
-            tuyadevices = json.load( infile )
+        tuyadevices = old_devices
     else:
         if 'apiDeviceID' in config and config['apiDeviceID'] and config['apiDeviceID'].strip().lower() == 'scan':
             config['apiDeviceID'] = ''
@@ -159,17 +163,21 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
             print('Check API Key and Secret')
             return
 
-        # Get UID from sample Device ID
-        json_data = cloud.getdevices( True )
+        # Fetch the DP name mappings for all devices
+        if quicklist:
+            answer = 'y'
+        else:
+            answer = input(subbold + '\nDownload DP Name mappings? ' + normal + '(Y/n): ')
+        include_map = not bool( answer[0:1].lower() == 'n' )
 
-        if 'result' not in json_data:
-            err = json_data['Payload'] if 'Payload' in json_data else 'Unknown Error'
+        # Get UID from sample Device ID
+        tuyadevices = cloud.getdevices( False, oldlist=old_devices, include_map=include_map )
+
+        if type(tuyadevices) != list:
+            err = tuyadevices['Payload'] if 'Payload' in tuyadevices else 'Unknown Error'
             print('\n\n' + bold + 'Error from Tuya server: ' + dim + err)
             print('Check DeviceID and Region')
             return
-
-        # Filter to only Name, ID and Key, IP and mac-address
-        tuyadevices = cloud.filter_devices( json_data['result'] )
 
     # The device list does not (always) tell us which device is the parent for a sub-device, so we need to try and figure it out
     # The only link between parent and child appears to be the local key
@@ -224,7 +232,7 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
     if not nocloud:
         # Save raw TuyaPlatform data to tuya-raw.json
         print(bold + "\n>> " + normal + "Saving raw TuyaPlatform response to " + RAWFILE)
-        json_data['file'] = {
+        cloud.getdevices_raw['file'] = {
             'name': RAWFILE,
             'description': 'Full raw list of Tuya devices.',
             'account': cloud.apiKey,
@@ -233,21 +241,9 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
         }
         try:
             with open(RAWFILE, "w") as outfile:
-                outfile.write(json.dumps(json_data, indent=4))
+                outfile.write(json.dumps(cloud.getdevices_raw, indent=4))
         except:
             print('\n\n' + bold + 'Unable to save raw file' + dim )
-
-    # Fetch the DP name mappings for all devices
-    if (not nocloud) and (not quicklist):
-        # Default to 'no'
-        answer = input(subbold + '\nDownload DP Name mappings? ' + normal + '(y/N): ')
-        if answer.lower().find('y') >= 0:
-            # load existing mappings so we only fetch mappings for newly-added devices
-            cloud.setmappings( tinytuya.load_dp_mappings() )
-            # fetch missing mappings
-            mappings = cloud.getmappings( tuyadevices )
-            tinytuya.save_dp_mappings( mappings )
-            print( bold + "\n>> " + normal + "Saved mappings for %d product IDs to %s" % (len(mappings), tinytuya.DPMAPPINGSFILE) )
 
     # Find out if we should poll all devices
     if quicklist:

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -237,10 +237,14 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
         except:
             print('\n\n' + bold + 'Unable to save raw file' + dim )
 
+    # Fetch the DP name mappings for all devices
     if (not nocloud) and (not quicklist):
+        # Default to 'no'
         answer = input(subbold + '\nDownload DP Name mappings? ' + normal + '(y/N): ')
         if answer.lower().find('y') >= 0:
+            # load existing mappings so we only fetch mappings for newly-added devices
             cloud.setmappings( tinytuya.load_mappings() )
+            # fetch missing mappings
             mappings = cloud.getmappings( tuyadevices )
             tinytuya.save_mappings( mappings )
             print( bold + "\n>> " + normal + "Saved mappings for %d product IDs to %s" % (len(mappings), tinytuya.DPMAPPINGSFILE) )

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -243,10 +243,10 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
         answer = input(subbold + '\nDownload DP Name mappings? ' + normal + '(y/N): ')
         if answer.lower().find('y') >= 0:
             # load existing mappings so we only fetch mappings for newly-added devices
-            cloud.setmappings( tinytuya.load_mappings() )
+            cloud.setmappings( tinytuya.load_dp_mappings() )
             # fetch missing mappings
             mappings = cloud.getmappings( tuyadevices )
-            tinytuya.save_mappings( mappings )
+            tinytuya.save_dp_mappings( mappings )
             print( bold + "\n>> " + normal + "Saved mappings for %d product IDs to %s" % (len(mappings), tinytuya.DPMAPPINGSFILE) )
 
     # Find out if we should poll all devices


### PR DESCRIPTION
Adds `mappings.json` to hold the DP<->Name mappings and various functions to download, save, and load it.  `mappings.json` contains a dict with product IDs as keys.

Submitting as a draft as I still need to add documentation but wanted to show the direction I was going in after the discussion in #353.