### PR TITLE
MappedDevice Phase II

### DIFF
--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -800,7 +800,7 @@ class Cloud(object):
                 if dp_id in dst:
                     continue
                 data = { 'code': code, 'type': mapp['type'] }
-                if mapp['type'].lower() == 'string':
+                if (mapp['type'].lower() == 'string') and (mapp['values'][0] != '{' or mapp['values'][-1] != '}'):
                     values = mapp['values']
                 else:
                     try:
@@ -827,7 +827,7 @@ class Cloud(object):
         if not self.mappings:
             self.mappings = {} #load_mappings()
 
-        if productid in self.mappings:
+        if productid and (productid in self.mappings):
             # already have this product id, so just return it
             return self.mappings[productid]
 
@@ -844,10 +844,14 @@ class Cloud(object):
                         self._build_mapping( result['status'], dps )
                     if 'functions' in result:
                         self._build_mapping( result['functions'], dps )
+                    if not productid:
+                        return dps
                     self.mappings[productid] = dps
                     log.debug( 'Downloaded mapping for device %r: %r', deviceid, dps)
                 elif ('code' in result and result['code'] == 2009) or ('msg' in result and result['msg'] == 'not support this device'):
                     # this device does not have any DPs!
+                    if not productid:
+                        return {}
                     self.mappings[productid] = {}
 
         if productid in self.mappings:

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -97,3 +97,4 @@ from .OutletDevice import OutletDevice
 from .CoverDevice import CoverDevice
 from .BulbDevice import BulbDevice
 from .Cloud import Cloud
+from .MappedDevice import MappedDevice

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -167,8 +167,11 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
         if quicklist:
             answer = 'y'
         else:
-            answer = input(subbold + '\nDownload DP Name mappings? ' + normal + '(Y/n): ')
+            answer = input(subbold + '\nDownload DP Name mappings? ' + normal + '([Y]es/[n]o/[a]ll): ')
         include_map = not bool( answer[0:1].lower() == 'n' )
+        if answer[0:1].lower() == 'a':
+            for dev in old_devices:
+                dev['mapping'] = None
 
         # Get UID from sample Device ID
         tuyadevices = cloud.getdevices( False, oldlist=old_devices, include_map=include_map )
@@ -178,6 +181,9 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
             print('\n\n' + bold + 'Error from Tuya server: ' + dim + err)
             print('Check DeviceID and Region')
             return
+
+        # Sort it by id
+        tuyadevices.sort( key=lambda dev: dev['id'] if 'id' in dev else '' )
 
     # The device list does not (always) tell us which device is the parent for a sub-device, so we need to try and figure it out
     # The only link between parent and child appears to be the local key
@@ -220,13 +226,14 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, quicklist=F
 
     # Display device list
     print("\n\n" + bold + "Device Listing\n" + dim)
-    output = json.dumps(tuyadevices, indent=4)  # sort_keys=True)
-    print(output)
+    print( json.dumps(tuyadevices[:15], indent=4) )
+    if len(tuyadevices) > 15:
+        print("%s(%d more devices hidden)" % (normal, (len(tuyadevices) - 15)))
 
     # Save list to devices.json
     print(bold + "\n>> " + normal + "Saving list to " + DEVICEFILE)
     with open(DEVICEFILE, "w") as outfile:
-        outfile.write(output)
+        json.dump(tuyadevices, outfile, indent=4)
     print(dim + "    %d registered devices saved" % len(tuyadevices))
 
     if not nocloud:


### PR DESCRIPTION
Draft for now as there are still a few FIXME's and errant print()'s, but I wanted some feedback on the direction I was going.

The scanner has also been updated to use it.  Instead of
```
### Thermostat   Product ID = sqkxklkleeasfk8w  [Valid Broadcast]:
    Address = ###   Device ID = ### (len:22)  Local Key = ###  Version = 3.3  Type = default, MAC = ###
    Status: {'2': 'cool', '16': 2650, '17': 80, '23': 'f', '24': 2400, '29': 75, '34': 51, '45': 0, '107': '4', '108': 2650, '109': 1500, '110': 80, '111': 59, '115': 'auto', '116': '1', '119': False, '120': 'followschedule', '123': 20, '129': 'alloff'}
```
you now get
```
### Thermostat   Product ID = sqkxklkleeasfk8w  [Valid Broadcast]:
    Address = ###   Device ID = ### (len:22)  Local Key = ###  Version = 3.3  Type = default, MAC = ###
    Status: {'mode': 'cool', 'temp_set': 26.5, 'temp_set_f': 80, 'temp_unit_convert': 'f', 'temp_current': 23.0, 'temp_current_f': 73, 'humidity': 50, 'fault': (), 'hvacsystemtype': '4', 'cool_set_temp': 26.5, 'heat_temp_set': 15.0, 'cool_set_temp_f': 80, 'heat_temp_set_f': 59, 'fanmode': 'auto', 'homemode': '1', 'schedule_enable': False, 'setpointholdmode': 'followschedule', 'fancylcetime': 20, 'relaystatus': 'alloff'}
```
As you can see, scaled ints are automatically turned into floats, enums are changed to their labels, and bitmasks are now lists of labels.  When setting, everything is converted back as needed.

When updates are received either via a status() response or an async update, the dps dict keys are mapped to the DP names.  If the received value is different than the last received value then the name is also added to a 'changed' list:
```
DEBUG:decoded results='{"dps":{"1":false},"t":1687500932}'
{'dps': {'switch_1': False}, 't': 1687500932, 'changed': ['switch_1']}
...
DEBUG:decoded results='{"dps":{"1":false},"t":1687500933}'
{'dps': {'switch_1': False}, 't': 1687500933, 'changed': []} # same value as last time, so not in 'changed'
```

In addition to this, the last received value for any particular DP can be retrieved at any time:
```python
d = MappedDevice(...)
d.status()
...
last_value = d['switch_1']
last_value = d.dps['switch_1'].value # same as above
```
The d.dps[...] object can also be used to get the int_min/int_max/enum_range/bitmask values for those data types as well as the DP ID and any name(s) associated with that DP, in addition to the last known (parsed) value and raw value.

Example d.dps[...] object for a bitmap:
```python
print(d.dps['fault'])
{'dp': '19', 'name': 'fault', 'names': ['19', 'fault', 'fault_alt_name'], 'raw_value': 1, 'value': ('cooling_fault',), 'enum_range': None, 'int_min': None, 'int_max': None, 'int_step': None, 'int_scale': None, 'bitmap': ('cooling_fault', 'heating_fault', 'temp_dif_fault'), 'bitmap_maxlen': 3}
```

Setting new values can be done in a similar dict-like manner; all of these are equivalent:
```python
d = MappedDevice(...)
...
d['switch_1'] = True
d[1] = True
d.dps['switch_1'].value = True
d.dps[1].value = True
d.set_value( 'switch_1', True )
d.set_value( 1, True )
d.turn_on( 'switch_1' )
d.turn_on() # works since default is switch=1
```

Since dict-like access cannot pass the `nowait` flag, there is now a device-level switch for it:
```python
d.set_nowait( True )
# or
d.set_nowait( False )
```

Todo:
Implement the 'Json' data type, implement `d.set_multiple_values()`, implement `d.set_timer()`, and cleanup and documentation.