### PR TITLE
Handle import issue with urllib3 #377

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # RELEASE NOTES
 
+## v1.12.9 - Import Issue with urllib3
+
+* PyPI 1.12.9
+* Add graceful handling of issue where urllib3 v2.0 causes `ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+` error. See https://github.com/jasonacox/tinytuya/issues/377.
+
 ## v1.12.8 - Device DP Mapping
 
 * PyPI 1.12.8

--- a/server/mqtt/mqtt_gateway.py
+++ b/server/mqtt/mqtt_gateway.py
@@ -16,7 +16,12 @@ import paho.mqtt.client as mqtt
 import time
 import logging
 import json
-import requests
+try:
+    import requests
+except ImportError as impErr:
+    print("WARN: Unable to import requests library, Cloud functions will not work.")
+    print("WARN: Check dependencies. See https://github.com/jasonacox/tinytuya/issues/377")
+    print("WARN: Error: {}.".format(impErr.args[0]))
 import sys
 import os
 import copy

--- a/server/server.py
+++ b/server/server.py
@@ -37,7 +37,12 @@ import time
 import logging
 import json
 import socket
-import requests
+try:
+    import requests
+except ImportError as impErr:
+    print("WARN: Unable to import requests library, Cloud functions will not work.")
+    print("WARN: Check dependencies. See https://github.com/jasonacox/tinytuya/issues/377")
+    print("WARN: Error: {}.".format(impErr.args[0]))
 import resource
 import sys
 import os

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -33,7 +33,12 @@ import hashlib
 import hmac
 import json
 import time
-import requests
+try:
+    import requests
+except ImportError as impErr:
+    print("WARN: Unable to import requests library, Cloud functions will not work.")
+    print("WARN: Check dependencies. See https://github.com/jasonacox/tinytuya/issues/377")
+    print("WARN: Error: {}.".format(impErr.args[0]))
 
 from .core import * # pylint: disable=W0401, W0614
 

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -97,7 +97,7 @@ except ImportError:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 12, 8)
+version_tuple = (1, 12, 9)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 


### PR DESCRIPTION
User @Frefdt reported import error in https://github.com/jasonacox/tinytuya/issues/377:

![image](https://github.com/jasonacox/tinytuya/assets/836718/2acb3b64-4344-4d47-b619-413b3880ebc8)

> ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the "ssl’ module is compiled with ‘OpenSSL 1.1.0h 27 Mar 2018". See: https://github.com/urllib3/urllib3/issues/2168

TinyTuya uses the `requests` library which uses `urllib3`. It seems that v2 of urllib3 now requires OpenSSL 1.1.1 but some python environments only have OpenSSL 1.1.0. This PR updates the `import requests` of TinyTuya to gracefully handle this error. 

```python
try:
    import requests
except ImportError as impErr:
    print("WARN: Unable to import requests library, Cloud functions will not work.")
    print("WARN: Check dependencies. See https://github.com/jasonacox/tinytuya/issues/377")
    print("WARN: Error: {}.".format(impErr.args[0]))
```
