### PR TITLE
Fix Cloud getdevices() bug for devices.json

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 
 * PyPI 1.12.9
 * Add graceful handling of issue where urllib3 v2.0 causes `ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+` error. See https://github.com/jasonacox/tinytuya/issues/377.
+* Fix bug in Cloud getdevices() that can error with older `devices.json` versions as raised in https://github.com/jasonacox/tinytuya/issues/381
 
 ## v1.12.8 - Device DP Mapping
 

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -469,7 +469,7 @@ class Cloud(object):
         changed_devices = []
         unchanged_devices = []
 
-        # chect to see if anything has changed.  if so, re-download factory-infos and DP mapping
+        # check to see if anything has changed.  if so, re-download factory-infos and DP mapping
         for dev in devs:
             dev_id = dev['id']
             if dev_id not in old_devices:
@@ -487,7 +487,7 @@ class Cloud(object):
                 continue
             is_same = True
             for k in DEVICEFILE_SAVE_VALUES:
-                if k in dev and k != 'icon' and k != 'last_ip' and old[k] != dev[k]:
+                if (k not in old) or (k in dev and k != 'icon' and k != 'last_ip' and old[k] != dev[k]):
                     is_same = False
                     break
             if not is_same:

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -487,7 +487,7 @@ class Cloud(object):
                 continue
             is_same = True
             for k in DEVICEFILE_SAVE_VALUES:
-                if (k not in old) or (k in dev and k != 'icon' and k != 'last_ip' and old[k] != dev[k]):
+                if k in dev and k != 'icon' and k != 'last_ip' and (k not in old or old[k] != dev[k]):
                     is_same = False
                     break
             if not is_same:


### PR DESCRIPTION
Running wizard with an older `devices.json` that is missing some of the newer keys (e.g. `model`) causes an error:

```
Traceback (most recent call last):
  File "/Users/jason/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/jason/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/jason/Code/tinytuya/tinytuya/__main__.py", line 76, in <module>
    wizard.wizard(color=color, retries=retries, forcescan=force, quicklist=assume_yes)
  File "/Users/jason/Code/tinytuya/tinytuya/wizard.py", line 174, in wizard
    tuyadevices = cloud.getdevices( False, oldlist=old_devices, include_map=include_map )
  File "/Users/jason/Code/tinytuya/tinytuya/Cloud.py", line 490, in getdevices
    if k in dev and k != 'icon' and k != 'last_ip' and old[k] != dev[k]:
KeyError: 'model'
```

This is due to an older `devices.json` not having the model key for some devices.  Updated to check for missing `DEVICEFILE_SAVE_VALUES` keys and update the device record.

Closes #381 
