### PR TITLE
Fixed endless loop causing 100% cpu usage

### DIFF
--- a/server/mqtt/mqtt_gateway.py
+++ b/server/mqtt/mqtt_gateway.py
@@ -212,5 +212,5 @@ if __name__ == "__main__":
             last = time.time()
             devices = getdevices()
             get_status_all(devices)
-    # Slow down
-    time.sleep(0.1)
+        # Slow down
+        time.sleep(0.1)


### PR DESCRIPTION
The sleep is outside the loop. This lead on a raspberry to hit 100% of cpu usage just for the gateway