### PR TITLE
Crypto lib changes and misc fixes

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -27,7 +27,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade pycryptodome requests colorama
+          python -m pip install --upgrade cryptography requests colorama
 
       - name: "Run testcontrib.py on ${{ matrix.python-version }}"
         run: "python -m testcontrib.py"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade pycryptodome requests colorama
+          python -m pip install --upgrade cryptography requests colorama
 
       - name: "Run test.py on ${{ matrix.python-version }}"
         run: "python -m test.py"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ TinyTuya supports python versions 2.7 and 3.x (recommended).
 python -m pip install tinytuya
 ```
 
-Pip will attempt to install `pycryptodome`, `requests` and `colorama` if not already installed.
+Pip will attempt to install `cryptography`, `requests` and `colorama` if not already installed.
 
 ## Tuya Device Preparation
 
@@ -419,7 +419,7 @@ print( json.dumps(r, indent=2) )
 
 ### Encryption Notes
 
-Tuya devices use AES encryption which is not available in the Python standard library. **PyCryptodome** is recommended and installed by default. Other options include **PyCrypto** and **pyaes**.
+Tuya devices use AES encryption which is not available in the Python standard library. **PyCA/cryptography** is recommended and installed by default. Other options include **PyCryptodome** , **PyCrypto** and **pyaes**.
 
 * Deprecation notice for pyaes: The pyaes library works for Tuya Protocol <= 3.4 but will not work for 3.5 devices. This is because pyaes does not support GCM which is required for v3.5 devices.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # RELEASE NOTES
 
+## v1.13.0 - Crypto Library Update
+
+* PyPI 1.13.0
+* Updates AESCipher() to make it a bit easier to add additional crypto libraries. It also adds pyca/cryptography as the default. By @uzlonewolf in https://github.com/jasonacox/tinytuya/pull/423
+* Fixes issue with tinytuya.find_device() for v3.1 devices and the infinite loop in Contrib/IRRemoteControlDevice.py (Closes #403).
+* Officially removes Python 2.7 support.
+
 ## v1.12.11 - Bug Fix for _get_socket()
 
 * PyPI 1.12.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 #
-pycryptodome        # Encryption - AES can also be provided via PyCrypto or pyaes or pyca/cryptography
+cryptography        # Encryption - AES can also be provided via PyCryptodome or pyaes or pyca/cryptography
 requests            # Used for Setup Wizard - Tuya IoT Platform calls
 colorama            # Makes ANSI escape character sequences work under MS Windows.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 #
-pycryptodome        # Encryption - AES can also be provided via PyCrypto or pyaes
+pycryptodome        # Encryption - AES can also be provided via PyCrypto or pyaes or pyca/cryptography
 requests            # Used for Setup Wizard - Tuya IoT Platform calls
 colorama            # Makes ANSI escape character sequences work under MS Windows.

--- a/server/server.py
+++ b/server/server.py
@@ -293,11 +293,7 @@ def tuyalisten(port):
         gwId = dname = dkey = mac = ""
         result = data
         try:
-            result = data[20:-8]
-            try:
-                result = tinytuya.decrypt_udp(result)
-            except:
-                result = result.decode()
+            result = tinytuya.decrypt_udp( data )
             result = json.loads(result)
             #log.debug("Received valid UDP packet: %r", result)
             ip = result["ip"]

--- a/server/server.py
+++ b/server/server.py
@@ -67,7 +67,7 @@ except:
 
 import tinytuya
 
-BUILD = "t8"
+BUILD = "t9"
 
 # Defaults
 APIPORT = 8888

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,33 @@
 import setuptools
+from pkg_resources import DistributionNotFound, get_distribution
 
 from tinytuya import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+INSTALL_REQUIRES = [
+    'requests',      # Used for Setup Wizard - Tuya IoT Platform calls
+    'colorama',      # Makes ANSI escape character sequences work under MS Windows.
+]
+
+CHOOSE_CRYPTO_LIB = [
+    'cryptography',  # pyca/cryptography - https://cryptography.io/en/latest/
+    'pycryptodome',  # PyCryptodome      - https://pycryptodome.readthedocs.io/en/latest/
+    'pyaes',         # pyaes             - https://github.com/ricmoo/pyaes
+    'pycrypto',      # PyCrypto          - https://www.pycrypto.org/
+]
+
+pref_lib = CHOOSE_CRYPTO_LIB[0]
+for cryptolib in CHOOSE_CRYPTO_LIB:
+    try:
+        get_distribution(cryptolib)
+        pref_lib = cryptolib
+        break
+    except DistributionNotFound:
+        pass
+
+INSTALL_REQUIRES.append( pref_lib )
 
 setuptools.setup(
     name="tinytuya",
@@ -15,11 +39,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url='https://github.com/jasonacox/tinytuya',
     packages=setuptools.find_packages(exclude=("sandbox",)),
-    install_requires=[
-        'pycryptodome',  # Encryption - AES can also be provided via PyCrypto or pyaes
-        'requests',      # Used for Setup Wizard - Tuya IoT Platform calls
-        'colorama',      # Makes ANSI escape character sequences work under MS Windows.
-    ],
+    install_requires=INSTALL_REQUIRES,
     classifiers=[
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",

--- a/tinytuya/Contrib/IRRemoteControlDevice.py
+++ b/tinytuya/Contrib/IRRemoteControlDevice.py
@@ -184,24 +184,18 @@ class IRRemoteControlDevice(Device):
         self.study_end()
         self.control_type = 0
         status = self.status()
-        while status:
-            if status and 'dps' in status:
-                # original devices using DPS 201/202
-                if self.DP_SEND_IR in status['dps']:
-                    log.debug( 'Detected control type 1' )
-                    self.control_type = 1
-                    break
-                # newer devices using DPS 1-13
-                elif self.DP_MODE in status['dps']:
-                    log.debug( 'Detected control type 2' )
-                    self.control_type = 2
-                    break
+        while status and 'dps' in status:
+            # original devices using DPS 201/202
+            if self.DP_SEND_IR in status['dps']:
+                log.debug( 'Detected control type 1' )
+                self.control_type = 1
+            # newer devices using DPS 1-13
+            elif self.DP_MODE in status['dps']:
+                log.debug( 'Detected control type 2' )
+                self.control_type = 2
             status = self._send_receive(None)
         if not self.control_type:
             log.warning( 'Detect control type failed! control_type= must be set manually' )
-        elif status:
-            # try and make sure no data is waiting to be read
-            status = self._send_receive(None)
         self.set_socketTimeout( old_timeout )
         self.set_socketPersistent( old_persist )
 

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -113,7 +113,7 @@ for clib in ('pyca/cryptography', 'PyCryptodomex', 'PyCrypto', 'pyaes'):
     except ImportError:
         continue
 if CRYPTOLIB is None:
-    raise ModuleNotFoundError('No crypto library found, please install one of: pyca/cryptography, PyCryptodome, or PyCrypto')
+    raise ModuleNotFoundError('No crypto library found, please "pip install" cryptography, pycryptodome, or pyaes')
 
 # Colorama terminal color capability for all platforms
 init()

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -96,15 +96,14 @@ for clib in ('pyca/cryptography', 'PyCryptodomex', 'PyCrypto', 'pyaes'):
             from cryptography.hazmat.primitives.ciphers import modes as Crypto_modes
             from cryptography.hazmat.primitives.ciphers.algorithms import AES
             from cryptography import __version__ as Crypto_version
-        elif clib == 'PyCryptodomex':
+        elif clib == 'PyCryptodomex': # https://pycryptodome.readthedocs.io/en/latest/
             # PyCryptodome is installed as "Cryptodome" when installed by
-            #  `apt install python3-pycryptodome` or
-            #  `pip3 install pycryptodomex`
+            #  `apt install python3-pycryptodome` or `pip install pycryptodomex`
             import Cryptodome as Crypto
             from Cryptodome.Cipher import AES
-        elif clib == 'PyCrypto':
+        elif clib == 'PyCrypto': # https://www.pycrypto.org/
             import Crypto
-            from Crypto.Cipher import AES  # PyCrypto
+            from Crypto.Cipher import AES
             # v1/v2 is PyCrypto, v3 is PyCryptodome
             clib = 'PyCrypto' if Crypto.version_info[0] < 3 else 'PyCryptodome'
         elif clib == 'pyaes':

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -108,6 +108,8 @@ for clib in ('pyca/cryptography', 'PyCryptodomex', 'PyCrypto', 'pyaes'):
             clib = 'PyCrypto' if Crypto.version_info[0] < 3 else 'PyCryptodome'
         elif clib == 'pyaes':
             import pyaes  # https://github.com/ricmoo/pyaes
+        else:
+            continue
         CRYPTOLIB = clib
         break
     except ImportError:
@@ -291,7 +293,7 @@ class _AESCipher_pyca(_AESCipher_Base):
             if header:
                 encryptor.authenticate_additional_data(header)
             crypted_text = encryptor.update(raw) + encryptor.finalize()
-            crypted_text = encryptor.initialization_vector + crypted_text + encryptor.tag
+            crypted_text = iv + crypted_text + encryptor.tag
         else:
             if pad: raw = self._pad(raw, 16)
             encryptor = Crypto( AES(self.key), Crypto_modes.ECB() ).encryptor()

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -251,7 +251,7 @@ class _AESCipher_Base(object):
 
     @classmethod
     def get_encryption_iv( cls, iv ):
-        if not self.CRYPTOLIB_HAS_GCM:
+        if not cls.CRYPTOLIB_HAS_GCM:
             raise NotImplementedError( 'Crypto library does not support GCM' )
         if iv is True:
             if log.isEnabledFor( logging.DEBUG ):
@@ -262,7 +262,7 @@ class _AESCipher_Base(object):
 
     @classmethod
     def get_decryption_iv( cls, iv, data ):
-        if not self.CRYPTOLIB_HAS_GCM:
+        if not cls.CRYPTOLIB_HAS_GCM:
             raise NotImplementedError( 'Crypto library does not support GCM' )
         if iv is True:
             iv = data[:12]

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -118,7 +118,7 @@ if CRYPTOLIB is None:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 12, 11)
+version_tuple = (1, 13, 0)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -1339,10 +1339,7 @@ def devices(verbose=False, scantime=None, color=True, poll=True, forcescan=False
             ip = addr[0]
             result = b''
             try:
-                if sock is client:
-                    result = tinytuya.unpack_message( data ).payload.decode()
-                else:
-                    result = tinytuya.decrypt_udp( data )
+                result = tinytuya.decrypt_udp( data )
                 result = json.loads(result)
                 log.debug("Received valid UDP packet: %r", result)
             except:

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -962,7 +962,7 @@ def devices(verbose=False, scantime=None, color=True, poll=True, forcescan=False
 
     Parameters:
         verbose = True or False, print formatted output to stdout [Default: False]
-        scantime = The time to wait to pick up UDP from all devices
+        scantime = The time to wait to pick up UDP from all devices (ignored when discover=False))
         color = True or False, print output in color [Default: True]
         poll = True or False, poll dps status for devices if possible
         forcescan = True, False, or a list of networks to force scan for device IP addresses

--- a/tools/pcap_parse.py
+++ b/tools/pcap_parse.py
@@ -279,7 +279,7 @@ def process_pcap( pcap_file, args ):
             continue
 
         if( isinstance(eth.ip.data, dpkt.udp.UDP) ):
-            if( eth.ip.udp.dport == 6667 and eth.ip.src not in ip_devs ):
+            if( (eth.ip.udp.dport == 6667 or eth.ip.udp.dport == 6666) and eth.ip.src not in ip_devs ):
                 try:
                     data = eth.ip.udp.data
                     devmac = mac_to_str( eth.src )


### PR DESCRIPTION
This PR reworks AESCipher() to make it a bit easier to add additional crypto libraries.  It also adds pyca/cryptography ( https://cryptography.io/en/latest/ ) which uses OpenSSL under the hood.  pyca/cryptography is preferred at runtime and in setup.py, but PyCryptodome is still preferred in requirements.txt.

An issue with tinytuya.find_device() for v3.1 devices has also been fixed, as has the infinite loop in Contrib/IRRemoteControlDevice.py (Closes #403).