### PR TITLE
Rewrite BulbDevice and rework set_multiple_values()

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,17 @@
 # RELEASE NOTES
 
+## v1.15.2 - Caching and BulbDevice updates
+
+* When a persistent connection is open, the new function `d.cached_status()` will return a cached version of the device status.
+    * When called as `d.cached_status(nowait=False)` (the default) a `d.status()` call will be made if no cached status is available.
+    * When called as `d.cached_status(nowait=True)` then `None` will be returned immediately if no cached status is available.
+* BulbDevice now uses the cached status (when available) to minimize the number of DPs sent when changing color.  Call `d.cache_clear()` before changing color to force it to send all DPs.
+* New device argument `max_simultaneous_dps` added to limit the number of simultaneous DP updates sent by `d.set_multiple_values()`.  Some bulbs cannot handle multiple DPs set in a single command and require `max_simultaneous_dps=1`. (#504)
+
+## v1.15.1 - Scanner Fixes
+
+* Fix scanner broadcast attempting to bind to the wrong IP address, introduced in v1.15.0
+
 ## v1.15.0 - Scanner Fixes
 
 * Fix force-scanning bug in scanner introduced in last release and add broadcast request feature to help discover Tuya version 3.5 devices by @uzlonewolf in https://github.com/jasonacox/tinytuya/pull/511.

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -276,7 +276,7 @@ class BulbDevice(Device):
 
         return self.set_value( self.DPS_INDEX_MODE[self.bulb_type], s, nowait=nowait )
 
-    def set_colour(self, r, g, b, nowait=False):
+    def set_colour(self, r, g, b, nowait=False, force=False):
         """
         Set colour of an rgb bulb.
 
@@ -319,7 +319,7 @@ class BulbDevice(Device):
 
         # check to see if power and mode also need to be set
         state = self.cached_status(nowait=True)
-        if state and self.DPS in state and state[self.DPS]:
+        if (not force) and state and self.DPS in state and state[self.DPS]:
             # last state is cached, so check to see if 'mode' needs to be set
             if (dp_index_mode not in state[self.DPS]) or (state[self.DPS][dp_index_mode] != self.DPS_MODE_COLOUR):
                 payload[dp_index_mode] = self.DPS_MODE_COLOUR
@@ -404,7 +404,7 @@ class BulbDevice(Device):
         data = self.set_white(b, c, nowait=nowait)
         return data
 
-    def set_white(self, brightness=-1, colourtemp=-1, nowait=False):
+    def set_white(self, brightness=-1, colourtemp=-1, nowait=False, force=False):
         """
         Set white coloured theme of an rgb bulb.
 
@@ -456,9 +456,9 @@ class BulbDevice(Device):
 
         # check to see if power and mode also need to be set
         state = self.cached_status(nowait=True)
-        if state and self.DPS in state and state[self.DPS]:
+        if (not force) and state and self.DPS in state and state[self.DPS]:
             # last state is cached, so check to see if 'mode' needs to be set
-            if (dp_index_mode not in state[self.DPS]) or (state[self.DPS][dp_index_mode] != self.DPS_MODE_COLOUR):
+            if (dp_index_mode not in state[self.DPS]) or (state[self.DPS][dp_index_mode] != self.DPS_MODE_WHITE):
                 payload[dp_index_mode] = self.DPS_MODE_WHITE
             # last state is cached, so check to see if 'power' needs to be set
             if (dp_index_on not in state[self.DPS]) or (not state[self.DPS][dp_index_on]):

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -34,7 +34,8 @@
 
 import colorsys
 
-from .core import * # pylint: disable=W0401, W0614
+from .core import Device, log
+from .core import error_json, ERR_JSON, ERR_RANGE, ERR_STATE
 
 class BulbDevice(Device):
     """

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -200,7 +200,7 @@ class BulbDevice(Device):
         else:
             # Unsupported bulb type
             raise ValueError(f"Unsupported bulb type {bulb} - unable to determine HSV values.")
-        
+
         return (h, s, v)
 
     def turn_on(self, switch=0, nowait=False):
@@ -276,7 +276,7 @@ class BulbDevice(Device):
 
         return self.set_value( self.DPS_INDEX_MODE[self.bulb_type], s, nowait=nowait )
 
-    def set_colour(self, r, g, b, nowait=False, force=False):
+    def set_colour(self, r, g, b, nowait=False):
         """
         Set colour of an rgb bulb.
 
@@ -319,7 +319,7 @@ class BulbDevice(Device):
 
         # check to see if power and mode also need to be set
         state = self.cached_status(nowait=True)
-        if (not force) and state and self.DPS in state and state[self.DPS]:
+        if state and self.DPS in state and state[self.DPS]:
             # last state is cached, so check to see if 'mode' needs to be set
             if (dp_index_mode not in state[self.DPS]) or (state[self.DPS][dp_index_mode] != self.DPS_MODE_COLOUR):
                 payload[dp_index_mode] = self.DPS_MODE_COLOUR
@@ -404,7 +404,7 @@ class BulbDevice(Device):
         data = self.set_white(b, c, nowait=nowait)
         return data
 
-    def set_white(self, brightness=-1, colourtemp=-1, nowait=False, force=False):
+    def set_white(self, brightness=-1, colourtemp=-1, nowait=False):
         """
         Set white coloured theme of an rgb bulb.
 
@@ -456,7 +456,7 @@ class BulbDevice(Device):
 
         # check to see if power and mode also need to be set
         state = self.cached_status(nowait=True)
-        if (not force) and state and self.DPS in state and state[self.DPS]:
+        if state and self.DPS in state and state[self.DPS]:
             # last state is cached, so check to see if 'mode' needs to be set
             if (dp_index_mode not in state[self.DPS]) or (state[self.DPS][dp_index_mode] != self.DPS_MODE_WHITE):
                 payload[dp_index_mode] = self.DPS_MODE_WHITE

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -35,7 +35,7 @@
 import colorsys
 
 from .core import Device, log
-from .core import error_json, ERR_JSON, ERR_RANGE, ERR_STATE, ERR_TIMEOUT
+from .core import error_json, ERR_JSON, ERR_RANGE, ERR_STATE, ERR_TIMEOUT, ERR_FUNCTION
 
 class BulbDevice(Device):
     """
@@ -532,7 +532,7 @@ class BulbDevice(Device):
                 if self.dpset[k]:
                     dps_values[self.dpset[k]] = check_values[k]
 
-        return self.set_multiple_values( payload, nowait=nowait )
+        return self.set_multiple_values( dps_values, nowait=nowait )
 
     def set_brightness_percentage(self, brightness=100, nowait=False):
         """

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -208,7 +208,7 @@ class BulbDevice(Device):
         super(BulbDevice, self).set_version(version)
 
         # Try to determine type of BulbDevice Type based on DPS indexes
-        status = self.status()
+        status = self.cached_status()
         if status is not None:
             if "dps" in status:
                 if "1" not in status["dps"]:
@@ -546,25 +546,25 @@ class BulbDevice(Device):
 
     def brightness(self):
         """Return brightness value"""
-        return self.status()[self.DPS][self.DPS_INDEX_BRIGHTNESS[self.bulb_type]]
+        return self.cached_status()[self.DPS][self.DPS_INDEX_BRIGHTNESS[self.bulb_type]]
 
     def colourtemp(self):
         """Return colour temperature"""
-        return self.status()[self.DPS][self.DPS_INDEX_COLOURTEMP[self.bulb_type]]
+        return self.cached_status()[self.DPS][self.DPS_INDEX_COLOURTEMP[self.bulb_type]]
 
     def colour_rgb(self):
         """Return colour as RGB value"""
-        hexvalue = self.status()[self.DPS][self.DPS_INDEX_COLOUR[self.bulb_type]]
+        hexvalue = self.cached_status()[self.DPS][self.DPS_INDEX_COLOUR[self.bulb_type]]
         return BulbDevice._hexvalue_to_rgb(hexvalue, self.bulb_type)
 
     def colour_hsv(self):
         """Return colour as HSV value"""
-        hexvalue = self.status()[self.DPS][self.DPS_INDEX_COLOUR[self.bulb_type]]
+        hexvalue = self.cached_status()[self.DPS][self.DPS_INDEX_COLOUR[self.bulb_type]]
         return BulbDevice._hexvalue_to_hsv(hexvalue, self.bulb_type)
 
     def state(self):
         """Return state of Bulb"""
-        status = self.status()
+        status = self.cached_status()
         state = {}
         if not status:
             return error_json(ERR_JSON, "state: empty response")

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -29,6 +29,10 @@
 
  Device Functions
     json = status()                    # returns json payload
+    json = cached_status(nowait=False) # When a persistent connection is open, this will return a cached version of the device status
+                                       #   if nowait=False (the default), a status() call will be made if no cached status is available.
+                                       #   if nowait=True, `None` will be returned immediately if no cached status is available.
+    cache_clear()                      # Clears the cache, causing cached_status() to either call status() or return None
     subdev_query(nowait)               # query sub-device status (only for gateway devices)
     set_version(version)               # 3.1 [default], 3.2, 3.3 or 3.4
     set_socketPersistent(False/True)   # False [default] or True
@@ -122,7 +126,7 @@ if CRYPTOLIB is None:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 15, 0)
+version_tuple = (1, 15, 2)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 
@@ -1583,7 +1587,17 @@ class XenonDevice(object):
         return data
 
     def cached_status(self, nowait=False):
-        """Return device last status."""
+        """
+        Return device last status if a persistent connection is open.
+
+        Args:
+            nowait(bool): If cached status is is not available, either call status() (when nowait=False) or immediately return None (when nowait=True)
+
+        Response:
+            json if cache is available, else
+                json from status() if nowait=False, or
+                None if nowait=True
+        """
         if (not self.socketPersistent) or (not self.socket) or (not self._last_status):
             if not nowait:
                 log.debug("Last status caching not available, requesting status from device")

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -1591,6 +1591,7 @@ class XenonDevice(object):
         return data
 
     def cached_status(self, nowait=False):
+        """Return device last status."""
         if (not self.socketPersistent) or (not self.socket) or (not self._last_status):
             if not nowait:
                 log.debug("Last status caching not available, requesting status from device")

--- a/tinytuya/core.py
+++ b/tinytuya/core.py
@@ -1590,7 +1590,7 @@ class XenonDevice(object):
 
         return data
 
-    def last_status(self, nowait=True):
+    def cached_status(self, nowait=False):
         if (not self.socketPersistent) or (not self.socket) or (not self._last_status):
             if not nowait:
                 log.debug("Last status caching not available, requesting status from device")


### PR DESCRIPTION
This is a pretty big rewrite to BulbDevice.  The fact that it connects to the bulb and calls `status()` as soon as the version is set has always bugged me, so now it delays that until a command is sent.  If a user calls `status()` themselves before they send a command then it uses the result from that status call instead of calling it again.

Also included are modifications to core: a caching mechanism has been added so devices can try to use cached DP values instead of making calls to the device, and `set_multiple_values()` has been modified to try and detect devices which fall over if they get sent multiple DPs in a single request.  The caching only works when an active persistent connection is open; closing the connection clears the cache since we won't get notified when DPs change.

To access the cache, call `d.cached_status(nowait)`.  When `nowait=True` then the cached value is returned if it is available or `None` if it is not.  When `nowait=False` then the cached value is returned if it is available or a call to `d.status()` is made if it is not.

BulbDevice now leans on the cache to try and minimize the number of DPs set in `set_white()` and `set_colour()`.  This combined with the `set_multiple_values()` change is to help with bulbs that only accept 1 DP at a time, such as @Anonymouse83's in #504.

Todo: update documentation.