### PR TITLE
Fix WinError 10022: Handle invalid socket arguments in send_discovery_request

### DIFF
--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -234,8 +234,11 @@ def send_discovery_request( iface_list=None ):
 
         log.debug( 'Sending discovery broadcast from %r to %r on port %r', address, iface['broadcast'], iface['port'] )
         # the official app always sends it twice, so do the same
-        iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
-        iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
+        try:
+            iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
+            iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
+        except socket.error as e:
+            log.error(f"Failed to send discovery broadcast to {iface['broadcast']}:{iface['port']}: {e}")
 
         if close_sockets:
             iface['socket'].close()


### PR DESCRIPTION
### **Overview**

This Pull Request addresses the `[WinError 10022] An invalid argument was supplied` error encountered when running the TinyTuya device scanner on Windows systems. The error occurs during the `sendto` operation in the `send_discovery_request` function within `scanner.py`.

### **Issue Details**

When executing the scan command, the following traceback is observed:

```
Traceback (most recent call last): File "<frozen runpy>", line 198, in _run_module_as_main ... OSError: [WinError 10022] An invalid argument was supplied
```