### PR TITLE
Revert "Fix WinError 10022: Handle invalid socket arguments in send_discovery_request"

### DIFF
--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -234,11 +234,8 @@ def send_discovery_request( iface_list=None ):
 
         log.debug( 'Sending discovery broadcast from %r to %r on port %r', address, iface['broadcast'], iface['port'] )
         # the official app always sends it twice, so do the same
-        try:
-            iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
-            iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
-        except socket.error as e:
-            log.error(f"Failed to send discovery broadcast to {iface['broadcast']}:{iface['port']}: {e}")
+        iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
+        iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
 
         if close_sockets:
             iface['socket'].close()


### PR DESCRIPTION
Reverts jasonacox/tinytuya#585

Based on @uzlonewolf comment - This could potentially hide an issue that needs to be addressed. Is there a better way to provide more information to the user than a WInError exception stack trace?