### PR TITLE
Add better error message when sending scanner broadcasts fails

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v1.16.1 - Scanner Error Handling
+
+* Adds error handling for cases when the scanner broadcasts fails by @x011 in https://github.com/jasonacox/tinytuya/pull/585 and @uzlonewolf in https://github.com/jasonacox/tinytuya/pull/587
+
 ## v1.16.0 - Code Refactoring
 
 * This update refactors core.py by splitting it up into smaller, more logical files. It puts it in a `core` directory, so existing code that imports from `tinytuya.core` should be unaffected.

--- a/tinytuya/core/core.py
+++ b/tinytuya/core/core.py
@@ -84,7 +84,7 @@ except NameError:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 16, 0)
+version_tuple = (1, 16, 1)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -213,6 +213,8 @@ def send_discovery_request( iface_list=None ):
             addr = client_bcast_addrs[bcast]
             iface_list[addr] = { 'broadcast': bcast }
 
+    at_least_one_succeeded = False
+    bcast_error_messages = []
     for address in iface_list:
         iface = iface_list[address]
         if 'socket' not in iface:
@@ -233,16 +235,22 @@ def send_discovery_request( iface_list=None ):
             iface['port'] = 7000
 
         log.debug( 'Sending discovery broadcast from %r to %r on port %r', address, iface['broadcast'], iface['port'] )
-        # the official app always sends it twice, so do the same
         try:
             iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
-            iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
+            at_least_one_succeeded = True
         except socket.error as e:
-            log.error(f"Failed to send discovery broadcast to {iface['broadcast']}:{iface['port']}: {e}")
+            log.debug( 'Failed to send discovery broadcast from %r to %r:%r', address, iface['broadcast'], iface['port'], exc_info=True )
+            bcast_error_messages.append( f"Failed to send discovery broadcast from {address} to {iface['broadcast']}:{iface['port']}: {e}" )
 
         if close_sockets:
             iface['socket'].close()
             del iface['socket']
+
+    if not at_least_one_succeeded:
+        if log.level != logging.DEBUG:
+            for line in bcast_error_messages:
+                log.error( line )
+        log.error( 'Sending broadcast discovery packet failed, certain v3.5 devices will not be found!' )
 
 class KeyObj(object):
     def __init__( self, gwId, key ):

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -239,7 +239,7 @@ def send_discovery_request( iface_list=None ):
             iface['socket'].sendto( iface['payload'], (iface['broadcast'], iface['port']) )
             at_least_one_succeeded = True
         except socket.error as e:
-            log.debug( 'Failed to send discovery broadcast from %r to %r:%r', address, iface['broadcast'], iface['port'], exc_info=True )
+            log.debug( f"Failed to send discovery broadcast from {address} to {iface['broadcast']}:{iface['port']}: {e}" )
             bcast_error_messages.append( f"Failed to send discovery broadcast from {address} to {iface['broadcast']}:{iface['port']}: {e}" )
 
         if close_sockets:


### PR DESCRIPTION
Modifies #585 to better warn users when sending broadcast discovery messages fails.  Because users may have VPNs and other non-broadcast-capable interfaces, the error is not displayed if sending on at least 1 interface succeeds.