### PR TITLE
Update music mode example showing how to build the payload.

### DIFF
--- a/examples/bulb-music.py
+++ b/examples/bulb-music.py
@@ -12,6 +12,7 @@
 """
 import tinytuya
 import time
+import random
 
 #tinytuya.set_debug()
 
@@ -40,12 +41,15 @@ print('Setting to Music')
 d.set_mode('music')
 data = d.status()
 
-# Send example music data to bulb 
-#  TODO: Figure out what the value does and how to use it to 
-#        represent real music data, beats, colors, fades
 x = 0
 while (x<20):
-    value = "%02d01" % x
+    # see: https://developer.tuya.com/en/docs/iot/solarlight-function-definition?id=K9tp16f086d5h#title-10-DP27(8)%3A%20music
+    hue = random.randint(0,360)
+    saturation = random.randint(0,1000)
+    brightness = random.randint(0,1000)
+    white_brightness = 0
+    temperature = 0
+    value = f"{mode:01X}{hue:04X}{saturation:04X}{brightness:04X}{white_brightness:04X}{temperature:04X}"
     print (" > Sending %s" % value)
     payload = d.generate_payload(tinytuya.CONTROL, {"27": value})
     d.send(payload)

--- a/examples/bulb-music.py
+++ b/examples/bulb-music.py
@@ -48,7 +48,7 @@ while (x<20):
     mode             = 0 # 0 - hard transitions (jumping), 1 - smooth transitions (gradient) 
     hue              = random.randint(0,360)  # 1111 (hue:        0–360,  0X0000–0X0168)
     saturation       = random.randint(0,1000) # 2222 (saturation: 0–1000, 0X0000–0X03E8)
-    brightness       = random.randint(0,1000) # 3333 (saturation: 0–1000, 0X0000–0X03E8)
+    brightness       = random.randint(0,1000) # 3333 (brightness: 0–1000, 0X0000–0X03E8)
     white_brightness = 0 # 4444: indicates brightness. It ranges from 0 to 1,000.
     temperature      = 0 # 5555: the temperature value (0–1000)
     value = f"{mode:01X}{hue:04X}{saturation:04X}{brightness:04X}{white_brightness:04X}{temperature:04X}"

--- a/examples/bulb-music.py
+++ b/examples/bulb-music.py
@@ -43,12 +43,14 @@ data = d.status()
 
 x = 0
 while (x<20):
+    # Value is 0 1111 2222 3333 4444 5555
     # see: https://developer.tuya.com/en/docs/iot/solarlight-function-definition?id=K9tp16f086d5h#title-10-DP27(8)%3A%20music
-    hue = random.randint(0,360)
-    saturation = random.randint(0,1000)
-    brightness = random.randint(0,1000)
-    white_brightness = 0
-    temperature = 0
+    mode             = 0 # 0 - hard transitions (jumping), 1 - smooth transitions (gradient) 
+    hue              = random.randint(0,360)  # 1111 (hue:        0–360,  0X0000–0X0168)
+    saturation       = random.randint(0,1000) # 2222 (saturation: 0–1000, 0X0000–0X03E8)
+    brightness       = random.randint(0,1000) # 3333 (saturation: 0–1000, 0X0000–0X03E8)
+    white_brightness = 0 # 4444: indicates brightness. It ranges from 0 to 1,000.
+    temperature      = 0 # 5555: the temperature value (0–1000)
     value = f"{mode:01X}{hue:04X}{saturation:04X}{brightness:04X}{white_brightness:04X}{temperature:04X}"
     print (" > Sending %s" % value)
     payload = d.generate_payload(tinytuya.CONTROL, {"27": value})


### PR DESCRIPTION
Maybe it would be nice to update the example to show how to build the payload for controlling the device in music mode.

[source](https://developer.tuya.com/en/docs/iot/solarlight-function-definition?id=K9tp16f086d5h#title-10-DP27(8)%3A%20music)

Probably closes #118 