### PR TITLE
Handle invalid binary data in the JSON from the device better

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v1.16.2 - Invalid JSON Handling
+
+* Handle invalid binary data in the JSON from the device better by @uzlonewolf in https://github.com/jasonacox/tinytuya/pull/607 re: #606
+
 ## v1.16.1 - Scanner Error Handling
 
 * Adds error handling for cases when the scanner broadcasts fails by @x011 in https://github.com/jasonacox/tinytuya/pull/585 and @uzlonewolf in https://github.com/jasonacox/tinytuya/pull/587

--- a/tinytuya/core/XenonDevice.py
+++ b/tinytuya/core/XenonDevice.py
@@ -743,11 +743,12 @@ class XenonDevice(object):
             try:
                 payload = payload.decode()
             except UnicodeDecodeError:
-                try:
-                    invalid_json = payload
-                    payload = payload.decode( errors='replace' )
-                except:
-                    pass
+                if (payload[:1] == b'{') and (payload[-1:] == b'}'):
+                    try:
+                        invalid_json = payload
+                        payload = payload.decode( errors='replace' )
+                    except:
+                        pass
             except:
                 pass
 

--- a/tinytuya/core/XenonDevice.py
+++ b/tinytuya/core/XenonDevice.py
@@ -700,7 +700,7 @@ class XenonDevice(object):
             payload = payload[len(H.PROTOCOL_VERSION_BYTES_31) :]
             # Decrypt payload
             # Remove 16-bytes of MD5 hexdigest of payload
-            payload = cipher.decrypt(payload[16:])
+            payload = cipher.decrypt(payload[16:], decode_text=False)
         elif self.version >= 3.2: # 3.2 or 3.3 or 3.4 or 3.5
             # Trim header for non-default device type
             if payload.startswith( self.version_bytes ):
@@ -713,7 +713,7 @@ class XenonDevice(object):
             if self.version < 3.4:
                 try:
                     log.debug("decrypting=%r", payload)
-                    payload = cipher.decrypt(payload, False)
+                    payload = cipher.decrypt(payload, False, decode_text=False)
                 except:
                     log.debug("incomplete payload=%r (len:%d)", payload, len(payload), exc_info=True)
                     return error_json(ERR_PAYLOAD)
@@ -722,13 +722,10 @@ class XenonDevice(object):
                 # Try to detect if device22 found
                 log.debug("payload type = %s", type(payload))
 
-            if not isinstance(payload, str):
-                try:
-                    payload = payload.decode()
-                except:
-                    log.debug("payload was not string type and decoding failed")
-                    return error_json(ERR_JSON, payload)
-            if not self.disabledetect and "data unvalid" in payload:
+            if isinstance(payload, str):
+                payload = payload.encode('utf-8')
+
+            if not self.disabledetect and b"data unvalid" in payload:
                 self.dev_type = "device22"
                 # set at least one DPS
                 self.dps_to_request = {"1": None}
@@ -741,13 +738,34 @@ class XenonDevice(object):
             log.debug("Unexpected payload=%r", payload)
             return error_json(ERR_PAYLOAD, payload)
 
+        invalid_json = None
         if not isinstance(payload, str):
-            payload = payload.decode()
+            try:
+                payload = payload.decode()
+            except UnicodeDecodeError:
+                try:
+                    invalid_json = payload
+                    payload = payload.decode( errors='replace' )
+                except:
+                    pass
+            except:
+                pass
+
+            # if .decode() threw an exception, `payload` will still be bytes
+            if not isinstance(payload, str):
+                log.debug("payload was not string type and decoding failed")
+                return error_json(ERR_JSON, payload)
+
         log.debug("decoded results=%r", payload)
         try:
             json_payload = json.loads(payload)
         except:
             json_payload = error_json(ERR_JSON, payload)
+            json_payload['invalid_json'] = payload
+
+        if invalid_json and isinstance(json_payload, dict):
+            # give it to the user so they can try to decode it if they want
+            json_payload['invalid_json'] = invalid_json
 
         # v3.4 stuffs it into {"data":{"dps":{"1":true}}, ...}
         if "dps" not in json_payload and "data" in json_payload and "dps" in json_payload['data']:

--- a/tinytuya/core/core.py
+++ b/tinytuya/core/core.py
@@ -84,7 +84,7 @@ except NameError:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 16, 1)
+version_tuple = (1, 16, 2)
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 


### PR DESCRIPTION
Some devices apparently return binary data in a DP string, which is a violation of the JSON spec.  Unfortunately I do not see any good way of telling it to ignore this and parse anyway (short of writing our own JSON parser, which I'm not about to do).  So, this PR tells payload.decode() to replace that bad binary data with the Unicode REPLACEMENT CHARACTER ("\uFFFD") and returns the bad payload in a new 'invalid_json' key for the user to deal with.  If the user cares they can check for the 'invalid_json' key and, if set, search the 'dps' dict for values containing "\uFFFD" to find out which ones were bad.

Closes #606