### PR TITLE
Build test updates

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -8,13 +8,11 @@ on:
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    runs-on: "ubuntu-24.04"
-    env:
-      USING_COVERAGE: '3.6,3.8'
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     env:
       USING_COVERAGE: '3.6,3.8'
 
@@ -17,8 +17,8 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,11 @@ on:
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    runs-on: "ubuntu-24.04"
-    env:
-      USING_COVERAGE: '3.6,3.8'
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     env:
       USING_COVERAGE: '3.6,3.8'
 


### PR DESCRIPTION
The 20.04 platform has been removed, so bump to 22.04.

Python 3.6 is not available on 22.04, so remove it.