### PR TITLE
Fix initialization bug with python2 (embedded devices)

### DIFF
--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -193,7 +193,9 @@ class BulbDevice(Device):
             b = int(rgb[2] * 255)
         else:
             # Unsupported bulb type
-            raise ValueError(f"Unsupported bulb type {bulb} - unable to determine RGB values.")
+            raise ValueError(
+                "Unsupported bulb type {} - unable to determine RGB values.".format(bulb)
+            )
 
         return (r, g, b)
 
@@ -217,7 +219,9 @@ class BulbDevice(Device):
             v = int(hexvalue[8:12], 16) / 1000.0
         else:
             # Unsupported bulb type
-            raise ValueError(f"Unsupported bulb type {bulb} - unable to determine HSV values.")
+            raise ValueError(
+                "Unsupported bulb type {} - unable to determine HSV values.".format(bulb)
+            )
         
         return (h, s, v)
 


### PR DESCRIPTION
Thanks for this software.

This PR fixes a SyntaxError while importing *tinytuya* with Python2 (`import tinytuya`), e.g. for embedded devices not supporting Python3. Error:

```
Python 2.7.18 (default, May  7 2025, 19:04:48)
[GCC 13.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import tinytuya
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "tinytuya/__init__.py", line 98, in <module>
    from .BulbDevice import BulbDevice
  File "tinytuya/BulbDevice.py", line 196
    raise ValueError(f"Unsupported bulb type {bulb} - unable to determine RGB values.")
                                                                                     ^
SyntaxError: invalid syntax
>>>
```