### PR TITLE
Fix BulbDevice for non-bulb devices

### DIFF
--- a/tinytuya/core/core.py
+++ b/tinytuya/core/core.py
@@ -93,7 +93,7 @@ except NameError:
 # Colorama terminal color capability for all platforms
 init()
 
-version_tuple = (1, 17, 0)  # Major, Minor, Patch
+version_tuple = (1, 17, 1)  # Major, Minor, Patch
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 


### PR DESCRIPTION
Some people may use BulbDevice as a default even for non-bulb devices, and turn_on()/turn_off() should still work even in that case.  See #572 