### PR TITLE
Add constructor option to specify configfile

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## 1.17.4
+
+- Cloud: Add `configFile` option to the Cloud constructor, allowing users to specify the config file location (default remains 'tinytuya.json') by @blackw1ng in https://github.com/jasonacox/tinytuya/pull/640
+
 ## v1.17.3 - Colorama Optional
 
 * This update makes the colorama dependency optional for the tinytuya library, allowing it to function without colorama while gracefully disabling color output. This will help with memory lor dependency limited platforms. Update by @uzlonewolf in https://github.com/jasonacox/tinytuya/pull/637. 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # RELEASE NOTES
 
-## 1.17.4
+## 1.17.4 - Cloud Config
 
 - Cloud: Add `configFile` option to the Cloud constructor, allowing users to specify the config file location (default remains 'tinytuya.json') by @blackw1ng in https://github.com/jasonacox/tinytuya/pull/640
 

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -52,7 +52,16 @@ class Cloud(object):
         Tuya Cloud IoT Platform Access
 
         Args:
-            initial_token: The auth token from a previous run.  It will be refreshed if it has expired
+            apiRegion (str, optional): Tuya API region code (e.g., 'us', 'eu', 'cn', 'in').
+            apiKey (str, optional): Tuya Cloud API key.
+            apiSecret (str, optional): Tuya Cloud API secret.
+            apiDeviceID (str, optional): Device ID for initial API calls.
+            new_sign_algorithm (bool, optional): Use new sign algorithm for API requests. Default: True.
+            initial_token (str, optional): The auth token from a previous run. It will be refreshed if expired.
+            configFile (str, optional): Path to the config file to use for credentials. Default: 'tinytuya.json'.
+            **extrakw: Additional keyword arguments for future compatibility.
+
+        If apiKey or apiSecret are not provided, credentials will be loaded from the config file.
 
         Playload Construction - Header Data:
             Parameter 	  Type    Required	Description

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -47,7 +47,7 @@ from .core import * # pylint: disable=W0401, W0614
 ########################################################
 
 class Cloud(object):
-    def __init__(self, apiRegion=None, apiKey=None, apiSecret=None, apiDeviceID=None, configFile='tinytuya.json', new_sign_algorithm=True, initial_token=None, **extrakw):
+    def __init__(self, apiRegion=None, apiKey=None, apiSecret=None, apiDeviceID=None, new_sign_algorithm=True, initial_token=None, configFile=CONFIGFILE, **extrakw):
         """
         Tuya Cloud IoT Platform Access
 

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -47,7 +47,7 @@ from .core import * # pylint: disable=W0401, W0614
 ########################################################
 
 class Cloud(object):
-    def __init__(self, apiRegion=None, apiKey=None, apiSecret=None, apiDeviceID=None, new_sign_algorithm=True, initial_token=None, **extrakw):
+    def __init__(self, apiRegion=None, apiKey=None, apiSecret=None, apiDeviceID=None, configFile='tinytuya.json', new_sign_algorithm=True, initial_token=None, **extrakw):
         """
         Tuya Cloud IoT Platform Access
 
@@ -77,7 +77,7 @@ class Cloud(object):
             * https://iot.tuya.com/cloud/products/detail
         """
         # Class Variables
-        self.CONFIGFILE = 'tinytuya.json'
+        self.CONFIGFILE = configFile
         self.apiRegion = apiRegion
         self.apiKey = apiKey
         self.apiSecret = apiSecret
@@ -894,3 +894,4 @@ class Cloud(object):
                 self.getmapping( productid, devid )
 
         return self.mappings
+

--- a/tinytuya/core/core.py
+++ b/tinytuya/core/core.py
@@ -101,7 +101,7 @@ except NameError:
 if HAVE_COLORAMA:
     init()
 
-version_tuple = (1, 17, 3)  # Major, Minor, Patch
+version_tuple = (1, 17, 4)  # Major, Minor, Patch
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 


### PR DESCRIPTION
Previously, CONFIGFILE was hardcoded to "tinytuya.json". This is now an option in the constructor to specify this, defaulting to the above.

This might be useful in settings where `tinytuya` is invoked in like cronjobs and we want to specify the location of the configfile ;)