### PR TITLE
Revert deprecated Contrib/__init__.py

### DIFF
--- a/tinytuya/Contrib/__init__.py
+++ b/tinytuya/Contrib/__init__.py
@@ -11,6 +11,5 @@ from .DoorbellDevice import DoorbellDevice
 from .ClimateDevice import ClimateDevice
 from .AtorchTemperatureControllerDevice import AtorchTemperatureControllerDevice
 from .InverterHeatPumpDevice import InverterHeatPumpDevice, TemperatureUnit, InverterHeatPumpMode, InverterHeatPumpFault
-from .SoriaInverterDevice import SoriaInverterDevice
 
-DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice", "ClimateDevice", "AtorchTemperatureControllerDevice", "InverterHeatPumpDevice", "SoriaInverterDevice"]
+DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice", "ClimateDevice", "AtorchTemperatureControllerDevice", "InverterHeatPumpDevice"]


### PR DESCRIPTION
I'm serious about deprecating this file...  Using it like we are was a mistake and I would delete it completely if I wasn't worried about breaking existing projects.  As I mentioned in #680 and at the top of the file itself, no new modules should be added to it.