### PR TITLE
fix: preserve device mappings on transient API failure in getdevices()

### DIFF
--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -528,13 +528,16 @@ class Cloud(object):
                             dev['mapping'] = mappings[productid]
 
             # Fallback: restore old mapping for changed devices that got no mapping back
-            # (API failure, rate limit, etc.) — use the mapping from oldlist if available
+            # (API failure, rate limit, etc.) — use the mapping from oldlist if available.
+            # Only fallback when the mapping is missing or explicitly None, so that an
+            # intentionally empty mapping {} (e.g. device with no DPs, cloud code 2009)
+            # is preserved rather than replaced with a potentially stale old mapping.
             for dev in changed_devices:
-                if not dev.get('mapping'):
+                if 'mapping' not in dev or dev['mapping'] is None:
                     dev_id = dev.get('id')
                     if dev_id and dev_id in old_devices:
                         old_mapping = old_devices[dev_id].get('mapping')
-                        if old_mapping:
+                        if old_mapping is not None:
                             dev['mapping'] = old_mapping
 
         log.debug( 'changed: %d', len(changed_devices) )

--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -519,10 +519,23 @@ class Cloud(object):
                 for dev in changed_devices:
                     if 'product_id' in dev and dev['product_id'] == productid:
                         dev['mapping'] = mappings[productid]
-                # also set unchanged devices just in case the mapping changed
-                for dev in unchanged_devices:
-                    if 'product_id' in dev and dev['product_id'] == productid:
-                        dev['mapping'] = mappings[productid]
+                # also set unchanged devices just in case the mapping changed,
+                # but only if the new mapping is non-empty (guard against overwriting
+                # a good cached mapping with an empty result from a transient API failure)
+                if mappings[productid]:
+                    for dev in unchanged_devices:
+                        if 'product_id' in dev and dev['product_id'] == productid:
+                            dev['mapping'] = mappings[productid]
+
+            # Fallback: restore old mapping for changed devices that got no mapping back
+            # (API failure, rate limit, etc.) — use the mapping from oldlist if available
+            for dev in changed_devices:
+                if not dev.get('mapping'):
+                    dev_id = dev.get('id')
+                    if dev_id and dev_id in old_devices:
+                        old_mapping = old_devices[dev_id].get('mapping')
+                        if old_mapping:
+                            dev['mapping'] = old_mapping
 
         log.debug( 'changed: %d', len(changed_devices) )
         log.debug( 'unchanged: %d', len(unchanged_devices) )


### PR DESCRIPTION
## Problem

When `/sync` triggers `getdevices(oldlist=..., include_map=True)` with a freshly-created `Cloud()` instance (empty mapping cache), two mapping-loss scenarios exist:

**1. Changed devices lose old mapping on API failure**
If `getmapping()` encounters a network error or rate limit, it returns `None` without setting `self.mappings[product_id]`. The product_id is absent from the returned `mappings` dict, so the assignment loop never fires. The device exits with no `mapping` key — the old mapping from `oldlist` is silently discarded and then overwritten on the next `tuyaSaveJson()` call.

**2. Unchanged devices have good mappings overwritten by empty results**
The `# also set unchanged devices` loop runs unconditionally. If a changed device returns an empty mapping `{}` (API code 2009 or edge-case empty response), all unchanged devices sharing that `product_id` also lose their mapping.

Fixes #439.

## Fix

Two targeted guards in `getdevices()`:

1. **Guard on unchanged-device overwrite:** only apply the new mapping to unchanged devices if it is non-empty (`if mappings[productid]:`).

2. **Old-mapping fallback for changed devices:** after `getmappings()`, any changed device that still has no mapping gets its old mapping restored from `old_devices` (already built at the top of the function).

No new data structures or API calls are introduced. The `old_devices` dict (built from `oldlist` at the function start) is reused.