### PR TITLE
fix(IRRemoteControlDevice): raise RuntimeError on undetected control_type in send_command()

### DIFF
--- a/tinytuya/Contrib/IRRemoteControlDevice.py
+++ b/tinytuya/Contrib/IRRemoteControlDevice.py
@@ -193,16 +193,9 @@ class IRRemoteControlDevice(Device):
             elif self.DP_MODE in status['dps']:
                 log.debug( 'Detected control type 2' )
                 self.control_type = 2
-            # Some devices (e.g. Aubess IR PRO) return an empty dps {} on status()
-            # but still respond to DPS 201 commands.  Fall back to control_type 1.
-            elif not status['dps']:
-                log.debug( 'Empty DPS in status response — falling back to control type 1 (DPS 201)' )
-                self.control_type = 1
             status = self._send_receive(None)
         if not self.control_type:
-            log.warning( 'Detect control type failed! Defaulting to control_type=1 (DPS 201). '
-                         'Override with control_type=1 or control_type=2 if needed.' )
-            self.control_type = 1
+            log.warning( 'Detect control type failed! control_type= must be set manually' )
         self.set_socketTimeout( old_timeout )
         self.set_socketPersistent( old_persist )
 

--- a/tinytuya/Contrib/IRRemoteControlDevice.py
+++ b/tinytuya/Contrib/IRRemoteControlDevice.py
@@ -193,13 +193,26 @@ class IRRemoteControlDevice(Device):
             elif self.DP_MODE in status['dps']:
                 log.debug( 'Detected control type 2' )
                 self.control_type = 2
+            # Some devices (e.g. Aubess IR PRO) return an empty dps {} on status()
+            # but still respond to DPS 201 commands.  Fall back to control_type 1.
+            elif not status['dps']:
+                log.debug( 'Empty DPS in status response — falling back to control type 1 (DPS 201)' )
+                self.control_type = 1
             status = self._send_receive(None)
         if not self.control_type:
-            log.warning( 'Detect control type failed! control_type= must be set manually' )
+            log.warning( 'Detect control type failed! Defaulting to control_type=1 (DPS 201). '
+                         'Override with control_type=1 or control_type=2 if needed.' )
+            self.control_type = 1
         self.set_socketTimeout( old_timeout )
         self.set_socketPersistent( old_persist )
 
     def send_command( self, mode, data={} ):
+        if not self.control_type:
+            raise RuntimeError(
+                'IRRemoteControlDevice: control_type has not been detected. '
+                'Pass control_type=1 (DPS 201/202) or control_type=2 (DPS 1-13) '
+                'to the constructor, or call detect_control_type() first.'
+            )
         if mode == 'send':
             if self.control_type == 1:
                 command = {

--- a/tinytuya/Contrib/IRRemoteControlDevice.py
+++ b/tinytuya/Contrib/IRRemoteControlDevice.py
@@ -206,7 +206,9 @@ class IRRemoteControlDevice(Device):
         self.set_socketTimeout( old_timeout )
         self.set_socketPersistent( old_persist )
 
-    def send_command( self, mode, data={} ):
+    def send_command( self, mode, data=None ):
+        if data is None:
+            data = {}
         if not self.control_type:
             raise RuntimeError(
                 'IRRemoteControlDevice: control_type has not been detected. '


### PR DESCRIPTION
## Summary

`send_command()` would silently no-op if `detect_control_type()` failed to identify the device type — leaving `control_type=0` with no error, no log output, and no IR signals sent. This made the failure very difficult to diagnose.

Surfaced in issue #492 where a user spent considerable time debugging before finding a workaround. (Note: the root cause in #492 was a leading `0` in `key1`, not a detection failure — but the silent no-op behavior is worth fixing regardless.)

## Changes

### `detect_control_type()` — cleaner failure logging
Removed the empty-DPS fallback and the detection-failure default that silently set `control_type=1`. If detection fails, `control_type` stays `0` and a warning is logged. Users can set `control_type` manually.

### `send_command()` — raise on undetected control_type
If `send_command()` is called with `control_type=0`, raise a clear `RuntimeError` with an actionable message instead of silently dropping the command. This surfaces the failure immediately and tells the user exactly what to do.

### `send_command()` — fix mutable default argument
Changed `data={}` default argument to `data=None` with an explicit guard inside the function, avoiding the Python mutable default argument pitfall.

## Review Notes

Per @uzlonewolf: blindly defaulting `control_type=1` on empty DPS would mask real detection failures. The `RuntimeError` in `send_command()` is the right place to catch undetected control types.

## Related Issues

Related to #492
