### PR TITLE
Handle devices being in a dict under 'devices' key in devices.json

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,6 +8,7 @@ Developer reference for all public classes, methods, and functions in TinyTuya.
 
 - [Class Hierarchy](#class-hierarchy)
 - [Module-Level Functions](#module-level-functions)
+- [File Formats](#file-formats)
 - [XenonDevice (Base Class)](#xenondevice-base-class)
 - [Device](#device)
 - [OutletDevice](#outletdevice)
@@ -92,6 +93,74 @@ Enable or disable verbose debug logging.
 ```python
 tinytuya.set_debug(True)
 ```
+
+### `load_devicefile(fname=None)`
+Load devices from a `devices.json` file, handling both accepted formats (flat list and wrapped dict).
+Returns a list of device dicts, or an empty list on failure.
+
+```python
+devices = tinytuya.load_devicefile()                  # uses default devices.json
+devices = tinytuya.load_devicefile('my_devices.json')  # custom path
+```
+
+---
+
+## File Formats
+
+### `devices.json`
+
+The `devices.json` file stores device metadata (ID, local key, name, IP, version, etc.) used by the library, the API server, and the CLI. TinyTuya accepts two formats:
+
+**Flat list** (written by the wizard and API server):
+
+```json
+[
+  {
+    "name": "Smart Plug",
+    "id": "ebfda...",
+    "key": "ab12cd34ef56gh78",
+    "ip": "192.168.1.50",
+    "version": "3.3"
+  }
+]
+```
+
+**Wrapped dict** (produced by some external tools):
+
+```json
+{
+  "devices": [
+    {
+      "name": "Smart Plug",
+      "id": "ebfda...",
+      "key": "ab12cd34ef56gh78",
+      "ip": "192.168.1.50",
+      "version": "3.3"
+    }
+  ]
+}
+```
+
+Both formats are accepted everywhere TinyTuya loads a device file — the library, CLI, scanner, wizard, and API server all normalise the input via `load_devicefile()`.
+
+**Required fields per device:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Tuya device ID (gwId) |
+| `key` | string | Local encryption key (may contain any printable characters including `'`, `` ` ``, `<`, `>`, etc.) |
+
+**Common optional fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Human-readable device name |
+| `ip` | string | Device IP address on the local network |
+| `version` | string | Protocol version (`"3.1"`, `"3.3"`, `"3.4"`, `"3.5"`) |
+| `mac` | string | Device MAC address |
+| `mapping` | object | DP code-to-ID mappings (from Cloud API) |
+
+> **Note:** The `key` field is a raw string — do not escape special characters. If editing `devices.json` by hand, use double-quoted JSON strings (JSON requires double quotes for string values, so characters like `'` are safe as-is inside them).
 
 ---
 

--- a/examples/devices.py
+++ b/examples/devices.py
@@ -32,12 +32,10 @@ def tuyaLookup(deviceid):
     return ("", "")
 
 # Read Devices.json 
-try:
-    # Load defaults
-    with open(DEVICEFILE) as f:
-        tuyadevices = json.load(f)
-        havekeys = True
-except:
+tuyadevices = tinytuya.load_devicefile(DEVICEFILE)
+if tuyadevices:
+    havekeys = True
+else:
     # No Device info
     print(alert + "\nNo devices.json file found." + normal)
     exit()

--- a/server/README.md
+++ b/server/README.md
@@ -113,6 +113,11 @@ The UI at http://localhost:8888 allows you to view and control the devices.
 
 ## Release Notes
 
+### p16 - Device File and Error Handling
+
+* Use centralized `tinytuya.load_devicefile()` to load `devices.json`, supporting both flat list and `{"devices": [...]}` wrapper formats. Fixes issue #532.
+* Add `isRegistered()` and `deviceError()` helpers to distinguish "Device offline" from "Device ID not found" in API error responses.
+
 ### p15 - Cross-Platform Memory Stats
 
 * Switched to using the `psutil` library for memory usage stats, making server.py fully cross-platform (Windows, macOS, Linux). Fixes issue #634.

--- a/server/server.py
+++ b/server/server.py
@@ -72,7 +72,7 @@ except:
 import tinytuya
 from tinytuya import scanner
 
-BUILD = "p15"
+BUILD = "p16"
 
 # Defaults from Environment
 APIPORT = int(os.getenv("APIPORT", "8888"))

--- a/server/server.py
+++ b/server/server.py
@@ -176,11 +176,11 @@ def isRegistered(deviceid):
             return True
     return False
 
-def deviceError(id):
+def deviceError(deviceid):
     # Return appropriate error dict: "Device offline" if registered, "Device ID not found" otherwise
-    if isRegistered(id):
-        return {"Error": "Device offline - registered but not discovered on the network.", "id": id}
-    return {"Error": "Device ID not found.", "id": id}
+    if isRegistered(deviceid):
+        return {"Error": "Device offline - registered but not discovered on the network.", "id": deviceid}
+    return {"Error": "Device ID not found.", "id": deviceid}
 
 def appenddevice(newdevice, devices):
     if newdevice["id"] in devices:

--- a/server/server.py
+++ b/server/server.py
@@ -169,6 +169,19 @@ def tuyaLookup(deviceid):
                 return (i["name"], i["key"], "")
     return ("", "", "")
 
+def isRegistered(deviceid):
+    # Check if a device ID exists in the registered devices list (tuyadevices)
+    for i in tuyadevices:
+        if isinstance(i, dict) and i.get("id") == deviceid:
+            return True
+    return False
+
+def deviceError(id):
+    # Return appropriate error dict: "Device offline" if registered, "Device ID not found" otherwise
+    if isRegistered(id):
+        return {"Error": "Device offline - registered but not discovered on the network.", "id": id}
+    return {"Error": "Device ID not found.", "id": id}
+
 def appenddevice(newdevice, devices):
     if newdevice["id"] in devices:
         return True
@@ -224,19 +237,7 @@ def get_static(web_root, fpath):
 
 def tuyaLoadJson():
     # Check to see if we have additional Device info
-    tdevices = []
-    try:
-        # Load defaults
-        with open(DEVICEFILE) as f:
-            tdevices = json.load(f)
-        if isinstance(tdevices, dict) and 'devices' in tdevices:
-            tdevices = tdevices['devices']
-        log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tdevices))
-    except:
-        # No Device info
-        log.debug("Device file %s could not be loaded", DEVICEFILE)
-
-    return tdevices
+    return tinytuya.load_devicefile(DEVICEFILE)
 
 def tuyaSaveJson():
     if not SAVEDEVICEFILE:
@@ -481,8 +482,8 @@ class handler(BaseHTTPRequestHandler):
                     message = formatreturn(d.set_value(dpsKey,dpsValue,nowait=True))
                     d.close()
                 else:
-                    message = json.dumps({"Error": "Device ID not found.", "id": id})
-                    log.debug("Device ID not found: %s" % id)
+                    message = json.dumps(deviceError(id))
+                    log.debug("Device not available: %s" % id)
             except:
                 message = json.dumps({"Error": "Syntax error in set command URL.", "url": self.path})
                 log.debug("Syntax error in set command URL: %s" % self.path)
@@ -502,8 +503,8 @@ class handler(BaseHTTPRequestHandler):
                     jout["id"] = id
                     message = json.dumps(jout)
                 else:
-                    message = json.dumps({"Error": "Device ID not found.", "id": id})
-                    log.debug("Device ID not found: %s" % id)
+                    message = json.dumps(deviceError(id))
+                    log.debug("Device not available: %s" % id)
         elif self.path.startswith('/turnoff/'):
             id = self.path.split('/turnoff/')[1]
             sw = 1
@@ -526,8 +527,8 @@ class handler(BaseHTTPRequestHandler):
                     message = json.dumps({"Error": "Error sending command to device.", "id": id})
                     log.debug("Error sending command to device: %s" % id)
             elif id != "":
-                message = json.dumps({"Error": "Device ID not found.", "id": id})      
-                log.debug("Device ID not found: %s" % id)      
+                message = json.dumps(deviceError(id))
+                log.debug("Device not available: %s" % id)
         elif self.path.startswith('/delayoff/'):
             id = self.path.split('/delayoff/')[1]
             sw = 1
@@ -554,8 +555,8 @@ class handler(BaseHTTPRequestHandler):
                     message = json.dumps({"Error": "Error sending command to device.", "id": id})
                     log.debug("Error sending command to device %s" % id)
             elif id != "":
-                message = json.dumps({"Error": "Device ID not found.", "id": id})
-                log.debug("Device ID not found: %s" % id)
+                message = json.dumps(deviceError(id))
+                log.debug("Device not available: %s" % id)
         elif self.path.startswith('/turnon/'):
             id = self.path.split('/turnon/')[1]
             sw = 1
@@ -578,8 +579,8 @@ class handler(BaseHTTPRequestHandler):
                     message = json.dumps({"Error": "Error sending command to device.", "id": id})
                     log.debug("Error sending command to device %s" % id)
             elif id != "":
-                message = json.dumps({"Error": "Device ID not found.", "id": id})     
-                log.debug("Device ID not found: %s" % id)        
+                message = json.dumps(deviceError(id))
+                log.debug("Device not available: %s" % id)
         elif self.path == '/numdevices':
             jout = {}
             jout["found"] = len(deviceslist)
@@ -612,8 +613,8 @@ class handler(BaseHTTPRequestHandler):
                     message = json.dumps({"Error": "Error polling device.", "id": id})
                     log.debug("Error polling device %s" % id)
             else:
-                message = json.dumps({"Error": "Device ID not found.", "id": id})
-                log.debug("Device ID not found: %s" % id)  
+                message = json.dumps(deviceError(id))
+                log.debug("Device not available: %s" % id)
         elif self.path == '/sync':
             if cloudconfig['apiKey'] == '' or cloudconfig['apiSecret'] == '' or cloudconfig['apiRegion'] == '' or cloudconfig['apiDeviceID'] == '':
                 message = json.dumps({"Error": "Cloud API config missing."})

--- a/server/server.py
+++ b/server/server.py
@@ -229,6 +229,8 @@ def tuyaLoadJson():
         # Load defaults
         with open(DEVICEFILE) as f:
             tdevices = json.load(f)
+        if isinstance(tdevices, dict) and 'devices' in tdevices:
+            tdevices = tdevices['devices']
         log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tdevices))
     except:
         # No Device info

--- a/tests.py
+++ b/tests.py
@@ -312,5 +312,77 @@ class TestRFRemoteControlDevice(unittest.TestCase):
         self.assertIn('ver', payload['key1'], "key1 missing 'ver'")
 
 
+class TestLoadDeviceFile(unittest.TestCase):
+    """Tests for the load_devicefile() helper."""
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir)
+
+    def _write_json(self, data, fname='devices.json'):
+        import os
+        path = os.path.join(self.tmpdir, fname)
+        with open(path, 'w') as f:
+            json.dump(data, f)
+        return path
+
+    def test_flat_list(self):
+        """Flat list format should be returned as-is."""
+        devices = [{'id': 'dev1', 'key': 'abc'}]
+        path = self._write_json(devices)
+        result = tinytuya.load_devicefile(path)
+        self.assertEqual(result, devices)
+
+    def test_wrapped_dict(self):
+        """Wrapped {"devices": [...]} format should return the inner list."""
+        devices = [{'id': 'dev2', 'key': 'xyz'}]
+        path = self._write_json({'devices': devices})
+        result = tinytuya.load_devicefile(path)
+        self.assertEqual(result, devices)
+
+    def test_missing_file(self):
+        """Missing file should return empty list, not raise."""
+        result = tinytuya.load_devicefile('/nonexistent_path/devices.json')
+        self.assertEqual(result, [])
+
+    def test_empty_list(self):
+        """Empty list should return empty list."""
+        path = self._write_json([])
+        result = tinytuya.load_devicefile(path)
+        self.assertEqual(result, [])
+
+    def test_invalid_json(self):
+        """Invalid JSON should return empty list, not raise."""
+        import os
+        path = os.path.join(self.tmpdir, 'bad.json')
+        with open(path, 'w') as f:
+            f.write('{not valid json')
+        result = tinytuya.load_devicefile(path)
+        self.assertEqual(result, [])
+
+    def test_non_list_non_dict(self):
+        """A JSON file containing a scalar should return empty list."""
+        path = self._write_json("just a string")
+        result = tinytuya.load_devicefile(path)
+        self.assertEqual(result, [])
+
+    def test_dict_without_devices_key(self):
+        """A dict without a 'devices' key should return empty list."""
+        path = self._write_json({'other_key': [{'id': 'x'}]})
+        result = tinytuya.load_devicefile(path)
+        self.assertEqual(result, [])
+
+    def test_special_chars_in_key(self):
+        """Keys with special characters should be preserved."""
+        devices = [{'id': 'dev3', 'key': ":|S'vf<MT6xhr{1~"}]
+        path = self._write_json(devices)
+        result = tinytuya.load_devicefile(path)
+        self.assertEqual(result[0]['key'], ":|S'vf<MT6xhr{1~")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -142,6 +142,8 @@ def _run_list_command(args):
     try:
         with open(device_file, 'r') as f:
             tuyadevices = json.load(f)
+        if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
+            tuyadevices = tuyadevices['devices']
     except FileNotFoundError:
         print('Error: device file "%s" not found.' % device_file)
         sys.exit(1)
@@ -199,6 +201,8 @@ def _run_device_command(args):
     try:
         with open(device_file, 'r') as f:
             tuyadevices = json.load(f)
+        if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
+            tuyadevices = tuyadevices['devices']
     except Exception:
         pass
 

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -27,6 +27,7 @@ except:
 
 from . import wizard, scanner, version, SCANTIME, DEVICEFILE, SNAPSHOTFILE, CONFIGFILE, RAWFILE, set_debug
 from .core import Device
+from .core.XenonDevice import load_devicefile
 
 prog = 'python3 -m tinytuya' if sys.argv[0][-11:] == '__main__.py' else None
 description = 'TinyTuya [%s]' % (version,)
@@ -139,16 +140,13 @@ if args.debug:
 def _run_list_command(args):
     """Handle the list command."""
     device_file = getattr(args, 'device_file', DEVICEFILE)
-    try:
-        with open(device_file, 'r') as f:
-            tuyadevices = json.load(f)
-        if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
-            tuyadevices = tuyadevices['devices']
-    except FileNotFoundError:
-        print('Error: device file "%s" not found.' % device_file)
-        sys.exit(1)
-    except Exception as e:
-        print('Error reading device file: %s' % e)
+    tuyadevices = load_devicefile(device_file)
+    if not tuyadevices:
+        import os
+        if not os.path.exists(device_file):
+            print('Error: device file "%s" not found.' % device_file)
+        else:
+            print('Error reading device file: %s' % device_file)
         sys.exit(1)
 
     FIELDS = ('name', 'id', 'key', 'ip', 'version')
@@ -197,14 +195,7 @@ def _run_device_command(args):
     dev_name    = getattr(args, 'name', None)
 
     # Load devices.json once (best-effort; missing file is fine)
-    tuyadevices = []
-    try:
-        with open(device_file, 'r') as f:
-            tuyadevices = json.load(f)
-        if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
-            tuyadevices = tuyadevices['devices']
-    except Exception:
-        pass
+    tuyadevices = load_devicefile(device_file)
 
     # Resolve --name to an ID
     if dev_name and not dev_id:

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -146,7 +146,7 @@ def _run_list_command(args):
         if not os.path.exists(device_file):
             print('Error: device file "%s" not found.' % device_file)
         else:
-            print('Error reading device file: %s' % device_file)
+            print('Error: device file "%s" contains no valid devices (check JSON syntax and format).' % device_file)
         sys.exit(1)
 
     FIELDS = ('name', 'id', 'key', 'ip', 'version')

--- a/tinytuya/core/XenonDevice.py
+++ b/tinytuya/core/XenonDevice.py
@@ -61,6 +61,32 @@ def find_device(dev_id=None, address=None):
     log.debug( 'find() is returning: %r', ret )
     return ret
 
+def load_devicefile(fname=None):
+    """Load devices from a devices.json file.
+
+    Handles both flat list and {"devices": [...]} dict formats.
+
+    Parameters:
+        fname = Path to the device file (default: DEVICEFILE)
+
+    Response:
+        list of device dicts, or empty list on failure
+    """
+    if not fname:
+        fname = DEVICEFILE
+    try:
+        with open(fname, 'r') as f:
+            data = json.load(f)
+        if isinstance(data, dict) and 'devices' in data:
+            data = data['devices']
+        if not isinstance(data, list):
+            data = []
+        log.debug("loaded=%s [%d devices]", fname, len(data))
+        return data
+    except:
+        log.debug("Device file %s could not be loaded", fname)
+        return []
+
 def device_info( dev_id ):
     """Searches the devices.json file for devices with ID = dev_id
 
@@ -72,17 +98,12 @@ def device_info( dev_id ):
     """
     devinfo = None
     try:
-        # Load defaults
-        with open(DEVICEFILE, 'r') as f:
-            tuyadevices = json.load(f)
-            if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
-                tuyadevices = tuyadevices['devices']
-            log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
-            for dev in tuyadevices:
-                if 'id' in dev and dev['id'] == dev_id:
-                    log.debug("Device %r found in %s", dev_id, DEVICEFILE)
-                    devinfo = dev
-                    break
+        tuyadevices = load_devicefile()
+        for dev in tuyadevices:
+            if 'id' in dev and dev['id'] == dev_id:
+                log.debug("Device %r found in %s", dev_id, DEVICEFILE)
+                devinfo = dev
+                break
     except:
         # No DEVICEFILE
         pass

--- a/tinytuya/core/XenonDevice.py
+++ b/tinytuya/core/XenonDevice.py
@@ -83,8 +83,8 @@ def load_devicefile(fname=None):
             data = []
         log.debug("loaded=%s [%d devices]", fname, len(data))
         return data
-    except:
-        log.debug("Device file %s could not be loaded", fname)
+    except Exception:
+        log.debug("Device file %s could not be loaded", fname, exc_info=True)
         return []
 
 def device_info( dev_id ):

--- a/tinytuya/core/XenonDevice.py
+++ b/tinytuya/core/XenonDevice.py
@@ -75,6 +75,8 @@ def device_info( dev_id ):
         # Load defaults
         with open(DEVICEFILE, 'r') as f:
             tuyadevices = json.load(f)
+            if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
+                tuyadevices = tuyadevices['devices']
             log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
             for dev in tuyadevices:
                 if 'id' in dev and dev['id'] == dev_id:

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -1184,6 +1184,8 @@ def devices(verbose=False, scantime=None, color=True, poll=True, forcescan=False
             with open(DEVICEFILE) as f:
                 tuyadevices = json.load(f)
                 havekeys = True
+                if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
+                    tuyadevices = tuyadevices['devices']
                 log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
         except:
             # No Device info
@@ -2026,6 +2028,8 @@ def alldevices(color=True, scantime=None, forcescan=False, discover=True, assume
         # Load defaults
         with open(DEVICEFILE) as f:
             tuyadevices = json.load(f)
+            if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
+                tuyadevices = tuyadevices['devices']
             log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
     except:
         print("%s ERROR: Missing %s file\n" % (term.alert, DEVICEFILE))

--- a/tinytuya/scanner.py
+++ b/tinytuya/scanner.py
@@ -1179,17 +1179,9 @@ def devices(verbose=False, scantime=None, color=True, poll=True, forcescan=False
     havekeys = False
     if not tuyadevices:
         # Check to see if we have additional Device info
-        try:
-            # Load defaults
-            with open(DEVICEFILE) as f:
-                tuyadevices = json.load(f)
-                havekeys = True
-                if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
-                    tuyadevices = tuyadevices['devices']
-                log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
-        except:
-            # No Device info
-            pass
+        tuyadevices = tinytuya.load_devicefile(DEVICEFILE)
+        if tuyadevices:
+            havekeys = True
 
     if forcescan and len(tuyadevices) == 0:
         if discover:
@@ -2024,15 +2016,9 @@ def alldevices(color=True, scantime=None, forcescan=False, discover=True, assume
         % (term.bold, term.normal, term.dim, tinytuya.__version__)
     )
     # Check to see if we have additional Device info
-    try:
-        # Load defaults
-        with open(DEVICEFILE) as f:
-            tuyadevices = json.load(f)
-            if isinstance(tuyadevices, dict) and 'devices' in tuyadevices:
-                tuyadevices = tuyadevices['devices']
-            log.debug("loaded=%s [%d devices]", DEVICEFILE, len(tuyadevices))
-    except:
-        print("%s ERROR: Missing %s file\n" % (term.alert, DEVICEFILE))
+    tuyadevices = tinytuya.load_devicefile(DEVICEFILE)
+    if not tuyadevices:
+        print("%s ERROR: Missing or empty %s file\n" % (term.alert, DEVICEFILE))
         return
 
     print("%sLoaded %s - %d devices:" % (term.dim, DEVICEFILE, len(tuyadevices)))

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -116,13 +116,8 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, assume_yes=
             if not config[k]:
                 needconfigs = True
 
-    try:
-        # Load the old device list, if available
-        with open(DEVICEFILE, "r") as infile:
-            old_devices = json.load( infile )
-            if isinstance(old_devices, dict) and 'devices' in old_devices:
-                old_devices = old_devices['devices']
-    except:
+    old_devices = tinytuya.load_devicefile(DEVICEFILE)
+    if not old_devices:
         old_devices = {}
 
     color = color and HAVE_COLOR

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -118,7 +118,7 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, assume_yes=
 
     old_devices = tinytuya.load_devicefile(DEVICEFILE)
     if not old_devices:
-        old_devices = {}
+        old_devices = []
 
     color = color and HAVE_COLOR
     (bold, subbold, normal, dim, alert, alertdim, cyan, red, yellow) = tinytuya.termcolor(color)

--- a/tinytuya/wizard.py
+++ b/tinytuya/wizard.py
@@ -120,6 +120,8 @@ def wizard(color=True, retries=None, forcescan=False, nocloud=False, assume_yes=
         # Load the old device list, if available
         with open(DEVICEFILE, "r") as infile:
             old_devices = json.load( infile )
+            if isinstance(old_devices, dict) and 'devices' in old_devices:
+                old_devices = old_devices['devices']
     except:
         old_devices = {}
 

--- a/tools/pcap_parse.py
+++ b/tools/pcap_parse.py
@@ -415,21 +415,21 @@ if __name__ == '__main__':
 
     if not args.devices:
         try:
-            with open( 'devices.json', 'rb' ) as fp:
-                devices = json.load( fp )
-            if not args.sortable:
-                print( 'Using \'devices.json\' for device keys' )
-        except Exception as e:
-            try:
-                with open( '../devices.json', 'rb' ) as fp:
-                    devices = json.load( fp )
+            devices = tinytuya.load_devicefile('devices.json')
+            if devices:
                 if not args.sortable:
-                    print( 'Using \'../devices.json\' for device keys' )
-            except:
-                raise e
+                    print( 'Using \'devices.json\' for device keys' )
+            else:
+                devices = tinytuya.load_devicefile('../devices.json')
+                if devices:
+                    if not args.sortable:
+                        print( 'Using \'../devices.json\' for device keys' )
+                else:
+                    raise FileNotFoundError('No devices.json found')
+        except Exception as e:
+            raise e
     else:
-        with open( args.devices, 'rb' ) as fp:
-            devices = json.load( fp )
+        devices = tinytuya.load_devicefile(args.devices)
 
     args.fnum = 0
     args.ftot = len(args.files)

--- a/tools/pcap_parse.py
+++ b/tools/pcap_parse.py
@@ -414,20 +414,17 @@ if __name__ == '__main__':
     args = arg_parser.parse_args()
 
     if not args.devices:
-        try:
-            devices = tinytuya.load_devicefile('devices.json')
+        devices = tinytuya.load_devicefile('devices.json')
+        if devices:
+            if not args.sortable:
+                print( 'Using \'devices.json\' for device keys' )
+        else:
+            devices = tinytuya.load_devicefile('../devices.json')
             if devices:
                 if not args.sortable:
-                    print( 'Using \'devices.json\' for device keys' )
+                    print( 'Using \'../devices.json\' for device keys' )
             else:
-                devices = tinytuya.load_devicefile('../devices.json')
-                if devices:
-                    if not args.sortable:
-                        print( 'Using \'../devices.json\' for device keys' )
-                else:
-                    raise FileNotFoundError('No devices.json found')
-        except Exception as e:
-            raise e
+                raise FileNotFoundError('No devices.json found')
     else:
         devices = tinytuya.load_devicefile(args.devices)
 


### PR DESCRIPTION
When loading devices.json, check to see if the result is a dict with a 'devices' key, and if so return that instead of the dict.  Fixes one of the issues in [ #532 ](https://github.com/jasonacox/tinytuya/issues/532#issuecomment-4231645355)