### PR TITLE
release: bump version to 1.18.1, update RELEASE.md for MAX_PAYLOAD_LENGTH fix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # RELEASE NOTES
 
+## v1.18.1 - IR Learn Frame Fix
+
+* core: Added `MAX_PAYLOAD_LENGTH` constant (default 1440 bytes) in `tinytuya/core/const.py` to replace the hardcoded 1000-byte ceiling in `parse_header()`. Enables local IR learn frame capture from devices with larger payloads such as AC IR blasters. Fixes [#708](https://github.com/jasonacox/tinytuya/issues/708) via [#709](https://github.com/jasonacox/tinytuya/pull/709) by @ostjen.
+
 ## v1.18.0 - Format Handling and UX Improvements
 
 * `devices.json` format: All loading paths (library, CLI, scanner, wizard, API server) now support both a flat `[{...}]` list and the `{"devices": [{...}]}` wrapped-dict format via a new centralized `load_devicefile()` helper. Fixes [#532](https://github.com/jasonacox/tinytuya/issues/532) via [#700](https://github.com/jasonacox/tinytuya/pull/700) by @uzlonewolf and @jasonacox.

--- a/tinytuya/core/core.py
+++ b/tinytuya/core/core.py
@@ -101,7 +101,7 @@ except NameError:
 if HAVE_COLORAMA:
     init()
 
-version_tuple = (1, 18, 0)  # Major, Minor, Patch
+version_tuple = (1, 18, 1)  # Major, Minor, Patch
 version = __version__ = "%d.%d.%d" % version_tuple
 __author__ = "jasonacox"
 


### PR DESCRIPTION
Increments version `1.18.0` → `1.18.1` and updates `RELEASE.md` in prep for PyPI release.

Changes:
- `tinytuya/core/core.py`: version tuple `(1, 18, 0)` → `(1, 18, 1)`
- `RELEASE.md`: adds v1.18.1 entry crediting @ostjen for the `MAX_PAYLOAD_LENGTH` fix (PR #709)

All 20 tests pass.

— Sam ⚙️