### PR TITLE
Add FloorFanDevice support for Comfort Zone floor standing tower fan (CZTF423S)

### DIFF
--- a/examples/Contrib/FloorFan-example.py
+++ b/examples/Contrib/FloorFan-example.py
@@ -30,8 +30,8 @@ def main():
     # Enable debug mode to see what's happening
     # fan.set_debug(True)
 
-    try:
-        print("=== Floor Standing Fan Control Example ===\n")
+    try:        # Note: Each status_json() call makes a full round-trip to the device.
+        # For production use, consider caching status or reducing polling frequency.        print("=== Floor Standing Fan Control Example ===\n")
 
         # Get the current status
         print("1. Getting current status...")

--- a/examples/Contrib/FloorFan-example.py
+++ b/examples/Contrib/FloorFan-example.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Example usage of FloorFanDevice from tinytuya
+
+This example shows how to use the FloorFanDevice class to control
+a Tuya floor standing fan device locally.
+"""
+
+import sys
+from tinytuya.Contrib.FloorFanDevice import FloorFanDevice
+
+# Device Configuration
+DEVICE_ID = "YOUR_DEVICE_ID"
+IP_ADDRESS = "YOUR_DEVICE_IP"
+LOCAL_KEY = "YOUR_LOCAL_KEY"
+VERSION = 3.3
+
+def main():
+    """
+    Main example function demonstrating FloorFanDevice usage
+    """
+    # Initialize the device
+    fan = FloorFanDevice(
+        DEVICE_ID,
+        IP_ADDRESS,
+        LOCAL_KEY,
+        version=VERSION
+    )
+
+    # Enable debug mode to see what's happening
+    # fan.set_debug(True)
+
+    try:
+        print("=== Floor Standing Fan Control Example ===\n")
+
+        # Get the current status
+        print("1. Getting current status...")
+        status = fan.status_json()
+        print(f"   Status: {status}\n")
+
+        # Control the fan
+        print("2. Turning on the fan...")
+        fan.set_power(True)
+        status = fan.status_json()
+        print(f"   Status: {status}\n")
+
+        # Set the mode
+        print("3. Setting wind mode to 'nature'...")
+        fan.set_mode("nature")
+        status = fan.status_json()
+        print(f"   Mode: {status['Mode']}\n")
+
+        # Set the speed
+        print("4. Setting fan speed to level 3...")
+        fan.set_speed(3)
+        status = fan.status_json()
+        print(f"   Speed: {status['Speed']}\n")
+
+        # Enable oscillation
+        print("5. Enabling oscillation...")
+        fan.set_oscillation(True)
+        status = fan.status_json()
+        print(f"   Oscillation: {status['Oscillation']}\n")
+
+        # Set a sleep timer
+        print("6. Setting sleep timer to 2 hours...")
+        fan.set_timer("2h")
+        status = fan.status_json()
+        print(f"   Timer: {status['Timer']}\n")
+
+        # Get individual status values
+        print("7. Reading individual status values...")
+        print(f"   Power: {fan.get_power()}")
+        print(f"   Mode: {fan.get_mode()}")
+        print(f"   Speed: {fan.get_speed()}")
+        print(f"   Oscillation: {fan.get_oscillation()}")
+        print(f"   Timer: {fan.get_timer()}\n")
+
+        # Turn off the fan
+        print("8. Turning off the fan...")
+        fan.set_power(False)
+        status = fan.status_json()
+        print(f"   Status: {status}\n")
+
+        print("Example completed successfully!")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/testcontrib.py
+++ b/testcontrib.py
@@ -2,20 +2,33 @@
 """
  TinyTuya test for Contrib
 
+ NOTE: Contrib/__init__.py is DEPRECATED — do not add new modules to it.
+   The old pattern `from tinytuya import Contrib` still works for backward
+   compatibility, but new device modules should be imported directly:
+       from tinytuya.Contrib import YourNewModule
+   See tinytuya/Contrib/__init__.py for details.
+
  Author: Jason A. Cox
  For more information see https://github.com/jasonacox/tinytuya
 """
 import tinytuya
-from tinytuya import Contrib
+
+# Preferred import pattern — import each module directly from tinytuya.Contrib
+from tinytuya.Contrib import ThermostatDevice, TemperatureUnit, InverterHeatPumpDevice
 
 print("TinyTuya (Contrib Import Test) [%s]\n" % tinytuya.__version__)
 
-print("   Contrib Devices Loaded: ")
+# Backward-compatible listing via the deprecated Contrib/__init__.py
+# This is kept for legacy visibility only — new devices do NOT need to be
+# registered in __init__.py.
+from tinytuya import Contrib
+print("   Contrib Devices Loaded (via deprecated __init__.py): ")
 for i in Contrib.DeviceTypes:
     print("      * %s" % i)
 
 print("   Test ThermostatDevice init(): ")
-d = Contrib.ThermostatDevice("abcdefghijklmnop123456", "172.28.321.475", "1234567890123abc")
+# Use the preferred import pattern (not Contrib.ThermostatDevice)
+d = ThermostatDevice("abcdefghijklmnop123456", "172.28.321.475", "1234567890123abc")
 
 import time
 import os
@@ -40,7 +53,8 @@ if IHP_DEVICEID and IHP_DEVICEIP and IHP_DEVICEKEY and IHP_DEVICEVERS:
     print("      * Device Version: %s" % IHP_DEVICEVERS)
     print()
 
-    device = Contrib.InverterHeatPumpDevice(
+    # Use the preferred import pattern (not Contrib.InverterHeatPumpDevice)
+    device = InverterHeatPumpDevice(
         dev_id=IHP_DEVICEID, address=IHP_DEVICEIP, local_key=IHP_DEVICEKEY, version=IHP_DEVICEVERS
     )
 
@@ -75,8 +89,8 @@ if IHP_DEVICEID and IHP_DEVICEIP and IHP_DEVICEKEY and IHP_DEVICEVERS:
     
     print("    Toggle unit")
     for unit_value in [not unit.value, unit.value]:
-        print("      * Setting unit to %r" % Contrib.TemperatureUnit(unit_value))
-        device.set_unit(Contrib.TemperatureUnit(unit_value))
+        print("      * Setting unit to %r" % TemperatureUnit(unit_value))
+        device.set_unit(TemperatureUnit(unit_value))
         time.sleep(5)
         print("      * get_unit(): %r" % device.get_unit())
         time.sleep(5)

--- a/tinytuya/Contrib/FloorFanDevice.py
+++ b/tinytuya/Contrib/FloorFanDevice.py
@@ -56,7 +56,6 @@ class FloorFanDevice(Device):
     DPS_MODE = "2"
     DPS_SPEED = "3"
     DPS_OSCILLATION = "5"
-    DPS_STATUS_FLAG = "13"
     DPS_TIMER = "22"
 
     def __init__(self, *args, **kwargs):
@@ -79,7 +78,7 @@ class FloorFanDevice(Device):
     def get_power(self):
         """Get the power status of the fan."""
         status = self.status()["dps"]
-        return status[self.DPS_POWER]
+        return status.get(self.DPS_POWER, False)
 
     def set_power(self, on):
         """Set the power status of the fan.
@@ -96,16 +95,19 @@ class FloorFanDevice(Device):
             str: One of 'normal', 'nature', or 'sleep'
         """
         status = self.status()["dps"]
-        return status[self.DPS_MODE]
+        return status.get(self.DPS_MODE, "normal")
 
     def set_mode(self, mode):
         """Set the wind mode.
         
         Args:
             mode (str): One of 'normal', 'nature', or 'sleep'
+            
+        Raises:
+            ValueError: If mode is not one of the valid options
         """
         if mode not in ("normal", "nature", "sleep"):
-            return
+            raise ValueError(f"Invalid mode '{mode}'. Must be one of: 'normal', 'nature', 'sleep'")
         self.set_value(self.DPS_MODE, mode)
 
     def get_speed(self):
@@ -115,16 +117,19 @@ class FloorFanDevice(Device):
             int: Speed level from 1 to 5
         """
         status = self.status()["dps"]
-        return status[self.DPS_SPEED]
+        return status.get(self.DPS_SPEED, 1)
 
     def set_speed(self, speed):
         """Set the fan speed level.
         
         Args:
             speed (int): Speed level from 1 to 5
+            
+        Raises:
+            ValueError: If speed is not between 1 and 5
         """
         if speed not in (1, 2, 3, 4, 5):
-            return
+            raise ValueError(f"Invalid speed {speed}. Must be between 1 and 5")
         self.set_value(self.DPS_SPEED, speed)
 
     def get_oscillation(self):
@@ -134,7 +139,7 @@ class FloorFanDevice(Device):
             bool: True if oscillation is on, False otherwise
         """
         status = self.status()["dps"]
-        return status[self.DPS_OSCILLATION]
+        return status.get(self.DPS_OSCILLATION, False)
 
     def set_oscillation(self, on):
         """Set the oscillation/swing status.
@@ -151,7 +156,7 @@ class FloorFanDevice(Device):
             str: One of 'cancel', '1h', '2h', ..., '12h'
         """
         status = self.status()["dps"]
-        return status[self.DPS_TIMER]
+        return status.get(self.DPS_TIMER, "cancel")
 
     def set_timer(self, timer):
         """Set the sleep timer.
@@ -159,11 +164,14 @@ class FloorFanDevice(Device):
         Args:
             timer (str): One of 'cancel', '1h', '2h', '3h', '4h', '5h', '6h', 
                         '7h', '8h', '9h', '10h', '11h', or '12h'
+                        
+        Raises:
+            ValueError: If timer is not one of the valid options
         """
         valid_timers = [
             "cancel", "1h", "2h", "3h", "4h", "5h", "6h",
             "7h", "8h", "9h", "10h", "11h", "12h"
         ]
         if timer not in valid_timers:
-            return
+            raise ValueError(f"Invalid timer '{timer}'. Must be one of: {', '.join(repr(t) for t in valid_timers)}")
         self.set_value(self.DPS_TIMER, timer)

--- a/tinytuya/Contrib/FloorFanDevice.py
+++ b/tinytuya/Contrib/FloorFanDevice.py
@@ -1,0 +1,169 @@
+from tinytuya.core import Device
+
+"""
+ Python module to interface with Tuya Floor Standing Fan devices
+
+ Local Control Classes
+    FloorFanDevice(..., version=3.3)
+        This class uses a default version of 3.3
+        See OutletDevice() for the other constructor arguments
+
+ Functions
+    FloorFanDevice:
+        status_json()
+        get_power()
+        set_power()
+        get_mode()
+        set_mode()
+        get_speed()
+        set_speed()
+        get_oscillation()
+        set_oscillation()
+        get_timer()
+        set_timer()
+    Inherited
+        json = status()                    # returns json payload
+        set_version(version)               # 3.1 [default] or 3.3
+        set_socketPersistent(False/True)   # False [default] or True
+        set_socketNODELAY(False/True)      # False or True [default]
+        set_socketRetryLimit(integer)      # retry count limit [default 5]
+        set_socketTimeout(timeout)         # set connection timeout in seconds [default 5]
+        set_dpsUsed(dps_to_request)        # add data points (DPS) to request
+        add_dps_to_request(index)          # add data point (DPS) index set to None
+        set_retry(retry=True)              # retry if response payload is truncated
+        set_status(on, switch=1, nowait)   # Set status of switch to 'on' or 'off' (bool)
+        set_value(index, value, nowait)    # Set int value of any index.
+        heartbeat(nowait)                  # Send heartbeat to device
+        updatedps(index=[1], nowait)       # Send updatedps command to device
+        turn_on(switch=1, nowait)          # Turn on device / switch #
+        turn_off(switch=1, nowait)         # Turn off
+        set_timer(num_secs, nowait)        # Set timer for num_secs
+        set_debug(toggle, color)           # Activate verbose debugging output
+        set_sendWait(num_secs)             # Time to wait after sending commands before pulling response
+        detect_available_dps()             # Return list of DPS available from device
+        generate_payload(command, data)    # Generate TuyaMessage payload for command with data
+        send(payload)                      # Send payload to device (do not wait for response)
+        receive()
+"""
+
+
+class FloorFanDevice(Device):
+    """
+    Represents a Tuya based Floor Standing Fan
+    """
+
+    DPS_POWER = "1"
+    DPS_MODE = "2"
+    DPS_SPEED = "3"
+    DPS_OSCILLATION = "5"
+    DPS_STATUS_FLAG = "13"
+    DPS_TIMER = "22"
+
+    def __init__(self, *args, **kwargs):
+        # set the default version to 3.3
+        if 'version' not in kwargs or not kwargs['version']:
+            kwargs['version'] = 3.3
+        super(FloorFanDevice, self).__init__(*args, **kwargs)
+
+    def status_json(self):
+        """Wrapper around status() that replace DPS indices with human readable labels."""
+        status = self.status()["dps"]
+        return {
+            "Power": status.get(self.DPS_POWER),
+            "Mode": status.get(self.DPS_MODE),
+            "Speed": status.get(self.DPS_SPEED),
+            "Oscillation": status.get(self.DPS_OSCILLATION),
+            "Timer": status.get(self.DPS_TIMER),
+        }
+
+    def get_power(self):
+        """Get the power status of the fan."""
+        status = self.status()["dps"]
+        return status[self.DPS_POWER]
+
+    def set_power(self, on):
+        """Set the power status of the fan.
+        
+        Args:
+            on (bool): True to turn on, False to turn off
+        """
+        self.set_status(on, self.DPS_POWER)
+
+    def get_mode(self):
+        """Get the current wind mode.
+        
+        Returns:
+            str: One of 'normal', 'nature', or 'sleep'
+        """
+        status = self.status()["dps"]
+        return status[self.DPS_MODE]
+
+    def set_mode(self, mode):
+        """Set the wind mode.
+        
+        Args:
+            mode (str): One of 'normal', 'nature', or 'sleep'
+        """
+        if mode not in ("normal", "nature", "sleep"):
+            return
+        self.set_value(self.DPS_MODE, mode)
+
+    def get_speed(self):
+        """Get the current fan speed level.
+        
+        Returns:
+            int: Speed level from 1 to 5
+        """
+        status = self.status()["dps"]
+        return status[self.DPS_SPEED]
+
+    def set_speed(self, speed):
+        """Set the fan speed level.
+        
+        Args:
+            speed (int): Speed level from 1 to 5
+        """
+        if speed not in (1, 2, 3, 4, 5):
+            return
+        self.set_value(self.DPS_SPEED, speed)
+
+    def get_oscillation(self):
+        """Get the oscillation/swing status.
+        
+        Returns:
+            bool: True if oscillation is on, False otherwise
+        """
+        status = self.status()["dps"]
+        return status[self.DPS_OSCILLATION]
+
+    def set_oscillation(self, on):
+        """Set the oscillation/swing status.
+        
+        Args:
+            on (bool): True to enable oscillation, False to disable
+        """
+        self.set_status(on, self.DPS_OSCILLATION)
+
+    def get_timer(self):
+        """Get the current sleep timer setting.
+        
+        Returns:
+            str: One of 'cancel', '1h', '2h', ..., '12h'
+        """
+        status = self.status()["dps"]
+        return status[self.DPS_TIMER]
+
+    def set_timer(self, timer):
+        """Set the sleep timer.
+        
+        Args:
+            timer (str): One of 'cancel', '1h', '2h', '3h', '4h', '5h', '6h', 
+                        '7h', '8h', '9h', '10h', '11h', or '12h'
+        """
+        valid_timers = [
+            "cancel", "1h", "2h", "3h", "4h", "5h", "6h",
+            "7h", "8h", "9h", "10h", "11h", "12h"
+        ]
+        if timer not in valid_timers:
+            return
+        self.set_value(self.DPS_TIMER, timer)

--- a/tinytuya/Contrib/README.md
+++ b/tinytuya/Contrib/README.md
@@ -14,9 +14,9 @@ In addition to the built-in `OutletDevice`, `BulbDevice` and `CoverDevice` devic
 
     ```python
     # Example usage of community contributed device modules
-    from tinytuya import Contrib
+    from tinytuya.Contrib import ThermostatDevice
 
-    thermo = Contrib.ThermostatDevice( 'abcdefghijklmnop123456', '172.28.321.475', '1234567890123abc' )
+    thermo = ThermostatDevice( 'abcdefghijklmnop123456', '172.28.321.475', '1234567890123abc' )
     ```
 
 ### IRRemoteControlDevice
@@ -26,24 +26,24 @@ In addition to the built-in `OutletDevice`, `BulbDevice` and `CoverDevice` devic
 * Example: [examples/IRRemoteControlDevice-example.py](https://github.com/jasonacox/tinytuya/blob/master/examples/Contrib/IRRemoteControlDevice-example.py)
 
     ```python
-    # Example 1 -usage of community contributed device modules
-    from tinytuya import Contrib
+    # Example 1 - usage of community contributed device modules
+    from tinytuya.Contrib import IRRemoteControlDevice
 
-    ir = Contrib.IRRemoteControlDevice( 'abcdefghijklmnop123456', '10.2.3.4', '1234567890123abc' )
+    ir = IRRemoteControlDevice( 'abcdefghijklmnop123456', '10.2.3.4', '1234567890123abc' )
     button = ir.receive_button(timeout=15)
     ir.send_button(button)
     ```
 
     ```python
     # Example 2 - Aubess WiFi IR Controller S16 for Sony TV - Issue #492
-    from tinytuya import Contrib
+    from tinytuya.Contrib import IRRemoteControlDevice
 
     # Pull the Device Log from Tuya cloud while using Tuya Smart App and pressing PWR button on controller:
     # SONY Tuya Device Debug Log: IR send{"control":"send_ir","head":"xxxx","key1":"003xxx)","type":0,"delay":300}
     head = 'xxx'
     key1 = '003xxx'
 
-    ir = Contrib.IRRemoteControlDevice( 'abcdefghijklmnop123456', '10.2.3.4', '1234567890123abc', persist=True )
+    ir = IRRemoteControlDevice( 'abcdefghijklmnop123456', '10.2.3.4', '1234567890123abc', persist=True )
     ir.send_key( head, key1 )
 
     # NOTE: If it doesn't work, try removing a leading zero from key1. Depending on what DPS set the device 
@@ -121,13 +121,13 @@ In addition to the built-in `OutletDevice`, `BulbDevice` and `CoverDevice` devic
 * Tested: Fairland Inverter+ 21kW (IPHR55)
 
     ```python
-    from tinytuya import Contrib
+    from tinytuya.Contrib import InverterHeatPumpDevice, TemperatureUnit, InverterHeatPumpFault
 
-    device = Contrib.InverterHeatPumpDevice(dev_id="devid", address="ip", local_key="key", version="3.3")
+    device = InverterHeatPumpDevice(dev_id="devid", address="ip", local_key="key", version="3.3")
 
-    device.set_unit(Contrib.TemperatureUnit.CELSIUS)
+    device.set_unit(TemperatureUnit.CELSIUS)
 
-    if device.get_fault() != Contrib.InverterHeatPumpFault.NOMINAL:
+    if device.get_fault() != InverterHeatPumpFault.NOMINAL:
         print("The inverter can't work normally. Turning off...")
         device.turn_off()
         exit()

--- a/tinytuya/Contrib/__init__.py
+++ b/tinytuya/Contrib/__init__.py
@@ -9,8 +9,7 @@ from .IRRemoteControlDevice import IRRemoteControlDevice
 from .SocketDevice import SocketDevice
 from .DoorbellDevice import DoorbellDevice
 from .ClimateDevice import ClimateDevice
-from .FloorFanDevice import FloorFanDevice
 from .AtorchTemperatureControllerDevice import AtorchTemperatureControllerDevice
 from .InverterHeatPumpDevice import InverterHeatPumpDevice, TemperatureUnit, InverterHeatPumpMode, InverterHeatPumpFault
 
-DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice", "ClimateDevice", "FloorFanDevice", "AtorchTemperatureControllerDevice", "InverterHeatPumpDevice"]
+DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice", "ClimateDevice", "AtorchTemperatureControllerDevice", "InverterHeatPumpDevice"]

--- a/tinytuya/Contrib/__init__.py
+++ b/tinytuya/Contrib/__init__.py
@@ -9,7 +9,8 @@ from .IRRemoteControlDevice import IRRemoteControlDevice
 from .SocketDevice import SocketDevice
 from .DoorbellDevice import DoorbellDevice
 from .ClimateDevice import ClimateDevice
+from .FloorFanDevice import FloorFanDevice
 from .AtorchTemperatureControllerDevice import AtorchTemperatureControllerDevice
 from .InverterHeatPumpDevice import InverterHeatPumpDevice, TemperatureUnit, InverterHeatPumpMode, InverterHeatPumpFault
 
-DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice", "ClimateDevice", "AtorchTemperatureControllerDevice", "InverterHeatPumpDevice"]
+DeviceTypes = ["ThermostatDevice", "IRRemoteControlDevice", "SocketDevice", "DoorbellDevice", "ClimateDevice", "FloorFanDevice", "AtorchTemperatureControllerDevice", "InverterHeatPumpDevice"]


### PR DESCRIPTION
- Implement FloorFanDevice class with support for:
  - Power control
  - Wind modes (normal, nature, sleep)
  - Speed levels (1-5)
  - Oscillation/swing control
  - Sleep timer (cancel, 1h-12h)
- Add comprehensive example usage in examples/Contrib/FloorFan-example.py
- Update Contrib __init__.py to export new device class