### PR TITLE
fix: call detect_bulb() in *_percentage() methods before reading value_max

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -259,6 +259,22 @@ class TestXenonDevice(unittest.TestCase):
         self.assertEqual(result_cmd, expected_cmd)
         self.assertDictEqual(result_payload, expected_payload)
 
+    def test_percentage_raises_when_unconfigured(self):
+        # Regression test: calling *_percentage() before bulb detection,
+        # with nowait=True and no cached status, should raise RuntimeError
+        # instead of silently computing with value_max=-1.
+        d = tinytuya.BulbDevice('DEVICE_ID_HERE', 'IP_ADDRESS_HERE', LOCAL_KEY)
+        d.set_version(3.3)
+        # No detect_bulb() called, no cached status available
+        d.cached_status = MagicMock(return_value=None)
+
+        with self.assertRaises(RuntimeError):
+            d.set_brightness_percentage(50, nowait=True)
+        with self.assertRaises(RuntimeError):
+            d.set_white_percentage(50, 50, nowait=True)
+        with self.assertRaises(RuntimeError):
+            d.set_colourtemp_percentage(50, nowait=True)
+
 
 def build_mock_rf():
     d = RFRemoteControlDevice('DEVICE_ID_HERE', 'IP_ADDRESS_HERE', LOCAL_KEY, control_type=1)

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -595,6 +595,8 @@ class BulbDevice(Device):
 
         if not self.bulb_configured:
             self.detect_bulb(nowait=nowait)
+            if not self.bulb_configured:
+                raise RuntimeError('set_white_percentage: Bulb not configured, cannot determine value ranges.')
 
         b = int(self.dpset['value_max'] * brightness // 100)
         c = int(self.dpset['value_max'] * colourtemp // 100)
@@ -661,6 +663,8 @@ class BulbDevice(Device):
             raise ValueError('set_brightness_percentage: The brightness needs to be between 0 and 100.')
         if not self.bulb_configured:
             self.detect_bulb(nowait=nowait)
+            if not self.bulb_configured:
+                raise RuntimeError('set_brightness_percentage: Bulb not configured, cannot determine value ranges.')
         b = int(self.dpset['value_max'] * brightness // 100)
         return self.set_brightness(b, nowait=nowait)
 
@@ -711,6 +715,8 @@ class BulbDevice(Device):
             raise ValueError( 'set_colourtemp_percentage: Colourtemp percentage needs to be between 0 and 100.')
         if not self.bulb_configured:
             self.detect_bulb(nowait=nowait)
+            if not self.bulb_configured:
+                raise RuntimeError('set_colourtemp_percentage: Bulb not configured, cannot determine value ranges.')
         c = int(self.dpset['value_max'] * colourtemp // 100)
         return self.set_colourtemp( c, nowait=nowait )
 

--- a/tinytuya/BulbDevice.py
+++ b/tinytuya/BulbDevice.py
@@ -593,6 +593,9 @@ class BulbDevice(Device):
         if err:
             raise ValueError( 'set_white_percentage: %s percentage needs to be between 0 and 100.' % err[1:])
 
+        if not self.bulb_configured:
+            self.detect_bulb(nowait=nowait)
+
         b = int(self.dpset['value_max'] * brightness // 100)
         c = int(self.dpset['value_max'] * colourtemp // 100)
 
@@ -656,6 +659,8 @@ class BulbDevice(Device):
         """
         if not 0 <= brightness <= 100:
             raise ValueError('set_brightness_percentage: The brightness needs to be between 0 and 100.')
+        if not self.bulb_configured:
+            self.detect_bulb(nowait=nowait)
         b = int(self.dpset['value_max'] * brightness // 100)
         return self.set_brightness(b, nowait=nowait)
 
@@ -704,6 +709,8 @@ class BulbDevice(Device):
         """
         if not 0 <= colourtemp <= 100:
             raise ValueError( 'set_colourtemp_percentage: Colourtemp percentage needs to be between 0 and 100.')
+        if not self.bulb_configured:
+            self.detect_bulb(nowait=nowait)
         c = int(self.dpset['value_max'] * colourtemp // 100)
         return self.set_colourtemp( c, nowait=nowait )
 


### PR DESCRIPTION
Fixes #713

## Problem

When `set_brightness_percentage()`, `set_white_percentage()`, or `set_colourtemp_percentage()` is called **before bulb detection has run**, `self.dpset['value_max']` is still `-1` (the unconfigured default). The computed raw value is wrong, which causes the `< 0` fallback in `set_brightness()` to fire and pin the device to full brightness regardless of the requested percentage.

## Fix

Add a `if not self.bulb_configured: self.detect_bulb(nowait=nowait)` guard at the top of each `_percentage()` method, before the `value_max` multiplication. This mirrors the guard already present in `set_brightness()`, `set_white()`, and other lower-level methods.

## Affected Methods

- `set_brightness_percentage()`
- `set_white_percentage()`
- `set_colourtemp_percentage()`

## Testing

Workaround confirmed by @andreidiaconescu18 in #713 — calling `d.status()` first (which triggers `detect_bulb()`) makes `set_brightness_percentage(75)` work correctly. This PR makes that detection automatic.

— Sam ⚙️