### PR TITLE
Fix for "Error in main loop: 'id'" of Force Scan

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -759,7 +759,10 @@ if __name__ == "__main__":
                 print(f" - ForceScan: Found {len(found)} devices")
                 for f in found:
                     log.debug(f"   - {found[f]}")
-                    gwId = found[f]["id"]
+                    gwId = found[f].get("id") or found[f].get("gwId")
+                    if not gwId:
+                        log.debug("Skipping force-scanned device with no id: %r", found[f])
+                        continue
                     result = {}
                     dname = dkey = mac = ""
                     try:


### PR DESCRIPTION
Force-scanned devices are returned keyed by IP and are not guaranteed to carry an "id" (only set when the local key is matched). Fall back to "gwId" and skip entries without one to avoid raising KeyError: 'id' in the main loop.