### PR TITLE
Cloud: send PUT/DELETE with the real HTTP method (fixes #716)

### DIFF
--- a/tinytuya/Cloud.py
+++ b/tinytuya/Cloud.py
@@ -231,11 +231,13 @@ class Cloud(object):
             )
         else:
             log.debug(
-                "POST: URL=%s HEADERS=%s DATA=%s", url, headers, body,
+                "%s: URL=%s HEADERS=%s DATA=%s", action, url, headers, body,
             )
-            response = requests.post(url, headers=headers, data=body)
+            # use the actual HTTP method (the signature is already computed with it);
+            # always sending POST here breaks PUT/DELETE endpoints (e.g. device rename)
+            response = requests.request(action, url, headers=headers, data=body)
             log.debug(
-                "POST RESPONSE: code=%d text=%s token=%s", response.status_code, response.text, self.token
+                "%s RESPONSE: code=%d text=%s token=%s", action, response.status_code, response.text, self.token
             )
 
         # Check to see if token is expired


### PR DESCRIPTION
Fixes #716.

`Cloud._tuyaplatform()` signs each request with the actual action (`PUT`/`DELETE`/…) but dispatches every non-`GET` call through `requests.post()`. Endpoints that require `PUT` or `DELETE` therefore receive a `POST` and Tuya rejects them with `1108 'uri path invalid'` — most visibly the device-rename endpoint `PUT /v1.0/devices/{device_id}`.

This swaps the catch-all `requests.post()` for `requests.request(action, ...)`, so the dispatched method matches the one already used to build the signature. `GET` keeps its dedicated branch; `POST` behaviour is unchanged.

Verified against the live EU cloud: before, the rename `PUT` returns `1108`; after, it returns `{'result': true, 'success': true}` and the new name shows up in the Smart Life app.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>