### PR TITLE
Add support for IPv6/NAT64 device connection addresses

### DIFF
--- a/tinytuya/core/XenonDevice.py
+++ b/tinytuya/core/XenonDevice.py
@@ -383,7 +383,8 @@ class XenonDevice(object):
                         log.debug("Bad local key length for device!")
                     return ERR_KEY_OR_VER
 
-                self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                family = socket.AF_INET6 if ':' in self.address else socket.AF_INET
+                self.socket = socket.socket(family, socket.SOCK_STREAM)
                 if self.socketNODELAY:
                     self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 self.socket.settimeout(self.connection_timeout)


### PR DESCRIPTION
Enable tinytuya to connect to Tuya devices via IPv6 addresses, primarily to support NAT64 environments where an IPv6-only host needs to reach IPv4 Tuya devices via a NAT64 gateway.

The socket address family is now selected dynamically based on the device address string: if the address contains a colon it is treated as IPv6 (AF_INET6), otherwise as IPv4 (AF_INET). This covers plain IPv6, NAT64-translated addresses (e.g. 64:ff9b::192.168.1.175), and IPv4-mapped IPv6 addresses (e.g. ::ffff:192.168.1.1).

Note: Device discovery is still IPv4-only.