### PR TITLE
Docs: README/PROTOCOL accuracy pass + DESIGN.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md — Guide for Coding Agents and Contributors
+
+TinyTuya is a Python library to control Tuya-based WiFi smart devices over the local network, plus a Tuya Cloud client, network scanner, setup wizard, and CLI. Read [DESIGN.md](DESIGN.md) for the architecture before changing core code, and [PROTOCOL.md](PROTOCOL.md) before touching anything on the wire path.
+
+## Quick Facts
+
+- **Language/support**: Python 3.7–3.12 (the CI matrix). Do not use syntax newer than 3.7 (no walrus in hot paths reviewed for 3.7, no `match`, no 3.8+-only typing). Python 2 shims (`IS_PY2`, `from __future__`) are dead code — do not extend them; removing them is welcome.
+- **Version source of truth**: `version_tuple` in `tinytuya/core/core.py`. Bump only as part of a release, together with a `RELEASE.md` entry.
+- **Dependencies**: `requests`, `colorama`, and exactly one AES backend (cryptography / PyCryptodome / pyaes / PyCrypto), auto-selected in `tinytuya/core/crypto_helper.py`. Do not add hard dependencies. Never import a crypto library outside `crypto_helper.py` — use `AESCipher`, and gate GCM-dependent features on `CRYPTOLIB_HAS_GCM`.
+
+## Build, Test, Lint
+
+```bash
+pip install -e .                     # dev install
+python -m tests                     # offline unit tests (tests.py) — must pass, no devices needed
+python test.py <ID> <IP> <KEY> <VER> # live smoke test against a real device (optional)
+pylint --recursive y -E tinytuya/    # errors-only lint, matches CI
+```
+
+CI (`.github/workflows/`) runs `tests.py` on Python 3.7–3.12, pylint (errors only), CodeQL, and `testcontrib.py` for Contrib modules. All must stay green.
+
+- Add regression tests to `tests.py` (unittest + `MagicMock` sockets — see existing tests for the pattern of mocking `_get_socket`/`send`/`receive`). Tests must run offline.
+- Contrib device classes get exercised by `testcontrib.py`.
+- For protocol work, `tools/fake-v35-device.py` emulates a v3.5 device locally; `tools/broadcast-relay.py` helps with discovery testing.
+
+## Code Conventions
+
+- **Error handling**: runtime device/cloud failures return `error_json()` dicts (`{"Error", "Err", "Payload"}`) — codes and messages live in `tinytuya/core/error_helper.py` (900–914). Do not raise exceptions for network/device failures in library paths; reserve exceptions for programmer errors and `DecodeError` for framing. New error codes go in the table there *and* in the README error table.
+- **Logging**: use the module `log = logging.getLogger(...)` objects; secrets (local keys, session keys, cloud apiSecret, tokens) must never appear in log output at any level, in `__repr__`, or in printed output. Guard expensive log formatting (e.g. hexlify) with `log.isEnabledFor(logging.DEBUG)`.
+- **Style**: no type annotations are used in this codebase — match that. 4-space indents, descriptive lowercase function names, existing docstring style (signature summary at module/class top). Keep the comment density of surrounding code. Code must pass `pylint -E`.
+- **Public API stability**: `tinytuya/__init__.py` wildcard-exports the core; a great deal of downstream code (Home Assistant integrations, forks, tutorials) depends on existing names, argument orders, and the error-dict shape. Never rename or reorder existing public parameters; add new parameters with defaults at the end. Deprecate softly (keep aliases) rather than removing.
+- **Protocol changes**: anything touching `message_helper.py`, `header.py`, `crypto_helper.py`, or `_encode_message`/`_decode_payload`/session negotiation in `XenonDevice.py` must be reflected in PROTOCOL.md in the same PR.
+- **Device quirks**: express per-version/per-dev_type command differences via the `payload_dict` template overlays in `XenonDevice.py`, not scattered `if version ==` branches.
+
+## Adding a Contrib Device Module
+
+New community device classes follow a fixed pattern (see existing modules in `tinytuya/Contrib/`):
+
+1. `tinytuya/Contrib/<Name>Device.py` — a class subclassing `Device`, category helpers only (no protocol logic), with a module docstring listing author, product, and usage.
+2. Add a section to `tinytuya/Contrib/README.md` (device, author link, usage snippet using `from tinytuya.Contrib import <Name>Device`).
+3. Add an example under `examples/Contrib/`.
+4. Add coverage in `testcontrib.py`.
+5. Add a `RELEASE.md` bullet crediting the contributor and PR number.
+
+## Documentation Map
+
+When behavior changes, update the matching docs in the same change:
+
+| Change | Update |
+|---|---|
+| Public API (methods, args, defaults) | `README.md` function lists + `tinytuya/__init__.py` docstring |
+| Wire protocol / framing / crypto | `PROTOCOL.md` |
+| Architecture / module boundaries | `DESIGN.md` |
+| Any user-visible change | `RELEASE.md` (bullet with PR # and author credit) |
+| New error code | `error_helper.py` + README error table |
+| Contrib module | `Contrib/README.md` + `examples/Contrib/` |
+
+Commit messages follow the loose `scope: summary` style visible in `git log` (e.g. `README: add auto_reconnect example`, `fix: call detect_bulb() before reading value_max`).
+
+## Safety Rails
+
+- **Never commit real credentials**: `devices.json`, `tinytuya.json`, `tuya-raw.json`, and `snapshot.json` contain local keys and/or cloud API secrets. Use obviously fake IDs/keys (`0123456789abcdef`, `abcdefghijklmnop123456`) in docs, examples, and tests.
+- **Files containing secrets** written by the wizard/scanner should be created with restrictive permissions (`0o600`) — preserve/extend this, don't regress it.
+- **Don't weaken crypto for convenience**: nonces/IVs must come from a proper source (`os.urandom`), never derived from time, constants, or log-level state. The static discovery key and ECB modes are Tuya protocol mandates — everything beyond that should follow modern practice.
+- **Be conservative on the device wire path**: retries, timeouts, and heartbeats interact with flaky consumer firmware; aggressive polling can crash devices. Changes to retry/persistence behavior need testing against real hardware or `tools/fake-v35-device.py` and a note in the PR.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,118 @@
+# TinyTuya Design
+
+This document describes the architecture of TinyTuya for contributors and coding agents. It explains how the pieces fit together, the design decisions behind them, and the known architectural debt. For contribution conventions (tests, style, release process), see [AGENTS.md](AGENTS.md). For the wire protocol itself, see [PROTOCOL.md](PROTOCOL.md).
+
+## Overview
+
+TinyTuya controls Tuya-based WiFi smart devices over the local network (LAN) and optionally via the Tuya Cloud API. The library speaks five generations of the Tuya LAN protocol (3.1 through 3.5) using synchronous TCP sockets — no asyncio, no per-device threads (the experimental `Monitor` class multiplexes many devices on one thread using `selectors`).
+
+```
+        User code
+           │
+   OutletDevice / BulbDevice / CoverDevice / Contrib.*      Cloud (REST)
+           │                                                    │
+        Device            ← user command API                requests
+           │
+       XenonDevice        ← sockets, framing, crypto, session keys,
+           │                payload templates, gateway routing
+     message_helper / crypto_helper / header / command_types
+           │
+        TCP 6668  +  UDP 6666/6667/7000 (discovery via scanner)
+```
+
+## Package Layout
+
+```
+tinytuya/
+├── __init__.py          Public API surface — wildcard re-exports from core,
+│                        plus OutletDevice, BulbDevice, CoverDevice, Cloud
+├── core/
+│   ├── core.py          Version (version_tuple), set_debug(), module-level
+│   │                    helpers (deviceScan, assign_dp_mappings, ...)
+│   ├── XenonDevice.py   Base device class (see below)
+│   ├── Device.py        User command API: set_status, set_value,
+│   │                    set_multiple_values, heartbeat, set_timer, ...
+│   ├── Monitor.py       EXPERIMENTAL single-thread multi-device monitor (#713)
+│   ├── message_helper.py  pack_message()/unpack_message() — 55AA + 6699 framing,
+│   │                    CRC32 / HMAC-SHA256 / AES-GCM integrity
+│   ├── crypto_helper.py AESCipher — backend-neutral AES (ECB + GCM)
+│   ├── header.py        Frame constants, TuyaMessage/MessagePayload namedtuples,
+│   │                    NO_PROTOCOL_HEADER_CMDS skip list
+│   ├── command_types.py Tuya LAN command IDs (DP_QUERY, CONTROL, ...)
+│   ├── const.py         Ports (6666/6667/6668/7000), timeouts, MAX_PAYLOAD_LENGTH
+│   ├── error_helper.py  Error codes 900–914 and error_json() builder
+│   ├── exceptions.py    DecodeError (framing/parse failures)
+│   └── udp_helper.py    Discovery broadcast decryption (static UDP key)
+├── OutletDevice.py      Thin Device subclass (set_dimmer)
+├── BulbDevice.py        Bulb type A/B/C detection, RGB/HSV ↔ Tuya hex conversion
+├── CoverDevice.py       8 command vocabularies with status-based autodetection
+├── Cloud.py             Tuya Cloud REST client — HMAC-SHA256 request signing,
+│                        token lifecycle, device list / DP mappings / logs
+├── scanner.py           Network discovery — select() event loop over UDP
+│                        listeners + optional TCP force-scan state machines
+├── wizard.py            Interactive setup: Cloud creds → devices.json keys →
+│                        scanner IP matching
+├── cli.py               Device control commands for the CLI (list/on/off/set/get/monitor)
+├── __main__.py          argparse dispatcher for `python -m tinytuya`
+└── Contrib/             Community-contributed device classes (see Contrib/README.md)
+```
+
+## Core Class Hierarchy
+
+`XenonDevice` (core/XenonDevice.py) is the base of every local device object. It owns:
+
+- **Socket lifecycle** — connect/retry policy (`connection_retry_limit`, `socketRetryDelay`), persistent vs per-call sockets (`set_socketPersistent`), auto-IP discovery via scanner when `address` is `None` or `'Auto'`.
+- **Payload templating** — a layered merge of the module-level `payload_dict` (default → gateway → zigbee → version → dev_type overlays), cached per instance as `self.payload_dict`. `generate_payload()` fills in device IDs, timestamps, and DPS values.
+- **Encryption orchestration** — `_encode_message()` / `_decode_payload()` apply the version-specific crypto described below.
+- **Session key negotiation** — the 3-message nonce exchange required by protocols 3.4/3.5 (`_negotiate_session_key*`). On success `self.local_key` becomes the session key; `self.real_local_key` keeps the device key.
+- **Gateway/sub-device routing** — children (`cid`/`node_id`) delegate send/receive and sequence numbers to their parent; responses are routed by `cid`, with out-of-order responses parked in `received_wrong_cid_queue`.
+- **device22 detection** — some devices (22-char IDs, and everything speaking 3.2) reject plain DP_QUERY with `"data unvalid"`; the library switches `dev_type` to `device22`, rewrites DP_QUERY → CONTROL_NEW with an explicit DPS list, and can brute-force available DPS (`detect_available_dps`).
+
+`Device` (core/Device.py) layers the user-facing command API on top. `OutletDevice`, `BulbDevice`, `CoverDevice`, and all `Contrib` classes subclass `Device` and add device-category helpers only — no protocol logic belongs in subclasses.
+
+## Message Flow
+
+**Send:** `generate_payload()` builds the JSON command → `MessagePayload(cmd, payload)` → `_encode_message()` encrypts/prefixes per protocol version → `pack_message()` frames it (prefix, seqno, cmd, length, CRC32/HMAC/GCM-tag, suffix) → `sendall()`.
+
+**Receive:** `_receive()` reads via `_recv_all()`, scans for the `55AA`/`6699` prefix to resync a desynced stream, `parse_header()` yields total length (bounded by `MAX_PAYLOAD_LENGTH`), `unpack_message()` verifies integrity and (for 6699) GCM-decrypts → `_decode_payload()` strips version headers, ECB-decrypts, JSON-parses → `_process_message()` handles device22 detection, child routing, and status caching → `_process_response()` is the subclass hook.
+
+## Protocol Versions
+
+| Version | Frame  | Integrity        | Payload crypto                                   | Session key |
+|---------|--------|------------------|--------------------------------------------------|-------------|
+| 3.1     | 55AA   | CRC32            | AES-ECB + base64, CONTROL only, MD5-fragment sig  | no          |
+| 3.2     | 55AA   | CRC32            | AES-ECB (binary); treated as device22             | no          |
+| 3.3     | 55AA   | CRC32            | AES-ECB (binary) + clear 15-byte version header   | no          |
+| 3.4     | 55AA   | HMAC-SHA256      | AES-ECB over the whole payload (incl. header)     | yes         |
+| 3.5     | 6699   | AES-GCM tag      | AES-GCM, 12-byte IV, retcode inside ciphertext    | yes         |
+
+Commands in `NO_PROTOCOL_HEADER_CMDS` (header.py) — DP_QUERY, DP_QUERY_NEW, UPDATEDPS, HEART_BEAT, the session-negotiation commands, LAN_EXT_STREAM — skip the `3.x` version header but not encryption. See PROTOCOL.md for byte-level detail.
+
+## Key Design Decisions
+
+- **Synchronous, dependency-light core.** The device stack uses only the standard library plus one AES backend. `requests` and `colorama` are needed only by Cloud/wizard/CLI paths. New hard dependencies require strong justification.
+- **Pluggable crypto backend.** `crypto_helper.py` selects pyca/cryptography → PyCryptodome(x) → PyCrypto → pyaes at import time and wraps whichever it finds in a single `AESCipher` class. Nothing else in the library may import a crypto library directly. pyaes has no GCM, so protocol 3.5 support is gated on `CRYPTOLIB_HAS_GCM`.
+- **Error dicts, not exceptions.** Runtime device failures return `error_json()` dicts (`{"Error", "Err", "Payload"}`, codes 900–914 in error_helper.py) so long-running callers don't need try/except around every poll. Exceptions are reserved for programmer errors and framing (`DecodeError`).
+- **Lazy scanner import.** `XenonDevice.find_device()` imports `..scanner` inside the function to avoid a circular import (scanner builds device objects; devices use the scanner for auto-IP).
+- **Version/behavior quirks live in data, not branches, where possible.** Per-version and per-dev_type command overrides are expressed in the `payload_dict` template structure rather than scattered conditionals.
+- **Monitor is a separate reactor, not a rewrite.** `Monitor` (experimental, #713) watches many persistent sockets with `selectors` on one thread, marshalling user commands via a locked queue + socketpair wake, with an optional connector thread for blocking reconnects. It currently duplicates `_receive()`'s framing logic for non-blocking buffered reads — a known refactoring target (extracting a shared frame codec).
+
+## Discovery
+
+Devices broadcast on UDP 6666 (3.1, plaintext) and 6667 (3.2+, AES-ECB under the well-known key `MD5("yGAdlopoPVldABfn")`); newer 3.5 devices stay silent until solicited via an app-style broadcast on UDP 7000 (6699/GCM frames, same key). `scanner.devices()` runs a single-threaded `select()` loop that listens on all three ports and can optionally "force scan" TCP 6668 across address ranges, brute-forcing version/key from `devices.json`. `udp_helper.decrypt_udp()` transparently handles raw-ECB, 55AA-framed, and 6699-GCM broadcast formats.
+
+## Cloud
+
+`Cloud` is a self-contained REST client for the Tuya IoT Platform: HMAC-SHA256 request signing (key + token + timestamp, alphabetically sorted query params), automatic token fetch/refresh, and helpers for device lists, DP mappings, logs, and commands. The wizard composes `Cloud` (to fetch local keys) with `scanner` (to find IPs) and writes `tinytuya.json` (credentials), `devices.json` (keys), and `tuya-raw.json` (raw API dump).
+
+## Known Architectural Debt
+
+Recorded here so future work moves toward the target state rather than adding to the pile:
+
+1. **`XenonDevice` is a god class** (~1350 lines): discovery, sockets, retry policy, three crypto generations, session negotiation, templating, gateway routing, and caching in one class. Target: extract a frame codec (shared with Monitor) and a transport object.
+2. **Four error-signaling conventions coexist** — error dicts (`_send_receive`), int-or-True (`_get_socket`), `None`/`True`/`False`/message (`_send_receive_quick`), and raised `RuntimeError` (auto-IP failure in `__init__`). New code should use `error_json()` dicts at API boundaries.
+3. **Network I/O inside constructors** — auto-IP scans the LAN in `__init__`; `set_version(3.2)` can trigger a multi-round-trip DPS scan. Prefer lazy/first-use I/O for new features.
+4. **`scanner.devices()` is a ~450-line function** driven by module-level globals that `__main__.py` mutates (`DEVICEFILE`, `SNAPSHOTFILE`), which makes the scanner awkward as a library. New scanner features should go into the `DeviceDetect` state-machine classes, not the main loop.
+5. **Wildcard re-exports without `__all__`** leak internals (`tinytuya.socket`, `tinytuya.json`, ...) into the public namespace, so renaming module-level names is riskier than it looks.
+6. **Monitor/`_receive()` framing duplication** — two independent implementations of prefix scanning and header parsing must be kept in sync until a shared codec exists.
+7. **Python 2 remnants** — `IS_PY2` branches and shims are dead (Monitor.py's f-strings make py2 imports fail anyway) and should be removed rather than extended.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -44,6 +44,9 @@ Cross-reference: framing & packing logic lives in `tinytuya/core/message_helper.
 0x0D CONTROL_NEW    New control frame (used for device22 + 3.4+ override)
 0x10 DP_QUERY_NEW   New DP query (used in 3.4+/3.5 overrides)
 0x12 UPDATEDPS      Request async DP refresh
+0x13 UDP_NEW        Encrypted UDP discovery broadcast (port 6667)
+0x23 BOARDCAST_LPV34 Discovery broadcast (v3.4)
+0x25 REQ_DEVINFO    Discovery solicitation request (UDP/7000, v3.5)
 0x03/0x04/0x05      Session key negotiation (3.4+)
 0x40 LAN_EXT_STREAM Extended (e.g., gateway subdevice ops)
 ```
@@ -56,26 +59,26 @@ Typical control payload (pre‑encryption) for a basic switch:
 3.4+/3.5 reduce required identifiers; many fields become optional (see per‑version details). Sub‑devices (Zigbee via gateway) add `cid` and wrap DPS inside `data`.
 
 ### Version Header ("3.x header")
-`<ascii version><12 x 0x00>` (e.g. `b"3.3\x00..."` length = 3 + 12). Presence and encryption differs by version and command (skipped for `DP_QUERY`, `UPDATEDPS`, `HEART_BEAT`, session negotiation, `LAN_EXT_STREAM`).
+`<ascii version><12 x 0x00>` (e.g. `b"3.3\x00..."` length = 3 + 12). Presence and encryption differs by version and command (skipped for `DP_QUERY`, `DP_QUERY_NEW`, `UPDATEDPS`, `HEART_BEAT`, session negotiation, `LAN_EXT_STREAM`).
 
 ### "Version Protocol" Source Header (overview)
-For v3.3+ some messages (STATUS/DP updates, sometimes CONTROL responses) begin with an additional 24-byte ASCII hex prefix before the encrypted or decrypted JSON payload:
+For v3.3+ some messages (STATUS/DP updates, sometimes CONTROL responses) begin with a 15-byte prefix before the encrypted or decrypted JSON payload: the ASCII version followed by three 32-bit big-endian binary fields (same overall size and position as the all-zeros version header):
 
-`3.xCCCCCCCCSSSSSSSSUUUUUUUU`
+`3.x | CCCC | SSSS | UUUU` (3 ASCII bytes + 4 + 4 + 4 binary bytes = 15 bytes)
 
 Where:
 * `3.x` – ASCII protocol version (e.g. `3.3`, `3.4`, `3.5`).
-* `CCCCCCCC` – 8 hex chars CRC32 of message for cloud/MQTT sourced traffic; `00000000` for LAN-sourced frames.
-* `SSSSSSSS` – 8 hex chars (32-bit) per-source monotonic sequence counter (device discards repeats or lower values for same `U`).
-* `UUUUUUUU` – 8 hex chars unique source identifier. Device uses `00000001`; clients should generate & persist a random non-zero value. Device caches only the last ~5 distinct IDs.
+* `CCCC` – 32-bit CRC32 of message for cloud/MQTT sourced traffic; zero for LAN-sourced frames.
+* `SSSS` – 32-bit per-source monotonic sequence counter (device discards repeats or lower values for same `U`).
+* `UUUU` – 32-bit unique source identifier. Device uses 1; clients should generate & persist a random non-zero value. Device caches only the last ~5 distinct IDs.
 
-If `UUUUUUUU == 00000000`, sequence checking is bypassed (all accepted). Header handling differs per version (clear vs encrypted) and is reiterated below per section for clarity.
+If the source identifier is 0, sequence checking is bypassed (all accepted). Header handling differs per version (clear vs encrypted) and is reiterated below per section for clarity. TinyTuya does not parse the individual fields; it simply strips the entire 15-byte block the same way it strips the all-zeros version header (`XenonDevice._decode_payload`).
 
 ### Header Types Quick Reference
 | Header Type | Byte Pattern | Purpose | Introduced | Visible in Clear | Encrypted With JSON? |
 |-------------|--------------|---------|------------|------------------|----------------------|
 | Version header | `3.x` + 12 zero bytes | Internal payload version marker | 3.2* | 3.2–3.3 yes (when present); 3.4+ no | 3.4+ yes |
-| Source header  | `3.xCCCCCCCCSSSSSSSSUUUUUUUU` | Per‑source sequencing & origin identity | 3.3 | 3.3 yes; 3.4+ no | 3.4+ yes |
+| Source header  | `3.x` + CRC32(4) + seq(4) + source id(4) | Per‑source sequencing & origin identity | 3.3 | 3.3 yes; 3.4+ no | 3.4+ yes |
 | 3.1 CONTROL prefix | `3.1` + 16 MD5 hex slice | Lightweight integrity tag for CONTROL | 3.1 | Yes | N/A (outer) |
 
 * Practical appearance begins with 3.2/3.3 devices. 3.1 does not embed a version header (only the CONTROL MD5 prefix). 3.1 and 3.2 do NOT use the Source header; its presence implies 3.3+.
@@ -118,6 +121,9 @@ If payload starts with `b"3.1"`, strip version + 16 md5 chars, base64‑decode r
 ### Version Protocol Source Header
 Not present (introduced later in 3.3). If you see a source header, firmware is not 3.1.
 
+### Discovery
+v3.1 devices announce themselves with plaintext JSON broadcasts on UDP/6666 — no key needed to read them. (Encrypted UDP/6667 broadcasts belong to 3.3+ firmware; see those sections.)
+
 ### Example (TinyTuya)
 ```python
 import tinytuya
@@ -150,13 +156,13 @@ Rare transitional variant; behaves almost identically to early 3.3 devices (ofte
 55AA frame identical to 3.3: seq | cmd | len | (retcode on replies) | payload | CRC32 | footer. CRC32 covers prefix through final payload byte (before CRC field).
 
 ### Encryption & Header Visibility
-Build JSON → AES-ECB (local key) → prepend clear version header `b"3.2" + 12*0x00` (unless command in skip list: DP_QUERY, UPDATEDPS, HEART_BEAT, handshake not applicable) → frame.
+Build JSON → AES-ECB (local key) → prepend clear version header `b"3.2" + 12*0x00` (unless command in skip list: DP_QUERY, DP_QUERY_NEW, UPDATEDPS, HEART_BEAT, LAN_EXT_STREAM; handshake not applicable) → frame.
 
 ### Version Protocol Source Header
 Not used in 3.2. Seeing one implies the device is actually 3.3+.
 
 ### DP Query / device22 Behavior
-Some 3.2 devices require explicit DPS list via `CONTROL_NEW` (device22 pattern). TinyTuya auto-detects on `data unvalid` and sets `dev_type='device22'`, switching query command & inserting null-valued DPS map.
+Most 3.2 devices require explicit DPS list via `CONTROL_NEW` (device22 pattern). TinyTuya does not wait for a `data unvalid` error here: `set_version(3.2)` unconditionally sets `dev_type='device22'` and, if no DPS are known yet, immediately brute-force scans for them (`detect_available_dps()`), switching the query command & inserting a null-valued DPS map. (The `data unvalid` auto-detection is only used for 3.3/3.4.)
 
 ### Example
 ```python
@@ -168,7 +174,7 @@ dev.set_value(1, True)     # CONTROL
 ```
 
 ### Notes
-- Minimal dedicated logic; treated like 3.3 variant internally.
+- Treated like a 3.3 variant internally, but always forced into device22 mode (with an up-front DPS brute-force scan) by `set_version(3.2)`.
 - Upgrade path firmware sometimes reports 3.2 but responds as 3.3 (library adapts).
 
 ---
@@ -194,30 +200,30 @@ For commands (except those in skip list):
 3. Prepend clear 3.x header (`b"3.3" + 12*0x00`).
 4. Frame in 55AA with CRC32.
 
-`DP_QUERY` / `UPDATEDPS` / `HEART_BEAT` are sent without the header (and for `DP_QUERY` may be empty JSON dict depending on device type). Some devices respond with encrypted payload that begins WITH the 3.3 header (clear) followed by ciphertext.
+`DP_QUERY` / `DP_QUERY_NEW` / `UPDATEDPS` / `HEART_BEAT` / `LAN_EXT_STREAM` are sent without the header (and for `DP_QUERY` may be empty JSON dict depending on device type). Some devices respond with encrypted payload that begins WITH the 3.3 header (clear) followed by ciphertext.
 
 ### "Version Protocol" Source Header (v3.3)
-Format (clear text at start of decrypted payload sequence):
+Format (clear, at start of the payload, 15 bytes total):
 
-`3.3CCCCCCCCSSSSSSSSUUUUUUUU`
+`3.3 | CRC32(4) | seq(4) | source id(4)`
 
 Where:
 * `3.3` – ASCII protocol version
-* `CCCCCCCC` – 8 hex chars CRC32 of message for cloud/MQTT sourced traffic; `00000000` for LAN-sourced frames.
-* `SSSSSSSS` – 8 hex chars (32-bit) per-source monotonic sequence counter (device discards repeats or lower values for same `U`).
-* `UUUUUUUU` – 8 hex chars unique source identifier. Device uses `00000001`; clients should generate & persist a random non-zero value. Device caches only the last ~5 distinct IDs.
+* `CRC32` – 32-bit CRC32 of message for cloud/MQTT sourced traffic; zero for LAN-sourced frames.
+* `seq` – 32-bit per-source monotonic sequence counter (device discards repeats or lower values for the same source id).
+* `source id` – 32-bit unique source identifier. Device uses 1; clients should generate & persist a random non-zero value. Device caches only the last ~5 distinct IDs.
 
 Handling:
 * Present mainly on STATUS / spontaneous updates.
-* Stripped by TinyTuya before JSON parsing.
-* LAN traffic normally shows `CCCCCCCC = 00000000`.
-* Provides duplicate-suppression and missed-message detection (look for gaps in `SSSSSSSS`).
+* TinyTuya strips the whole 15-byte block before JSON parsing (same code path as the all-zeros version header; the individual fields are not parsed).
+* LAN traffic normally shows CRC32 = 0.
+* Provides duplicate-suppression and missed-message detection (look for gaps in the sequence field).
 
 ### Discovery
-Legacy broadcast (UDP/6667). No solicitation port 7000 behavior (see 3.5).
+Legacy broadcast (UDP/6667), AES-ECB encrypted with the well-known key `MD5(b"yGAdlopoPVldABfn")` — the same key later reused for 3.5 GCM discovery. (Plaintext UDP/6666 broadcasts are only sent by 3.1 devices.) No solicitation port 7000 behavior (see 3.5).
 
 ### Device22 Behavior
-If device replies with error substring `data unvalid` while using default type, TinyTuya flips to `dev_type="device22"`:
+If device replies with error substring `data unvalid` while using default type, TinyTuya flips to `dev_type="device22"` (this auto-detection fires only for 3.3/3.4):
 * `DP_QUERY` uses command ID 0x0D (`CONTROL_NEW`).
 * Payload includes explicit DPS map (keys mapped to `null`).
 * Library maintains `dps_to_request` (auto-populated via brute force if needed).
@@ -276,7 +282,7 @@ Encryption differences:
 All multi‑byte integers are big‑endian. Aside from the HMAC vs CRC and encrypted version header, v3.4 framing is identical to prior 55AA revisions.
 
 ### Session Key Handshake
-Commands: START (0x03), RESP (0x04), FINISH (0x05). All three use normal 55AA framing; RESP payload is AES-ECB encrypted; START and FINISH payloads are plaintext nonces/HMACs.
+Commands: START (0x03), RESP (0x04), FINISH (0x05). All three use normal 55AA framing, and all three payloads are AES-ECB encrypted with the real (static) local key — the nonces/HMACs are never sent in the clear. (These commands skip only the version header.)
 
 Handshake Sequence:
 ```mermaid
@@ -284,22 +290,22 @@ sequenceDiagram
     autonumber
     participant C as Client
     participant D as Device
-    C->>D: SESS_KEY_NEG_START (cmd=0x03) payload = client_nonce (16B)
+    C->>D: SESS_KEY_NEG_START (cmd=0x03) payload = ENC( client_nonce (16B) )
     D-->>C: SESS_KEY_NEG_RESP (0x04) payload = ENC( device_nonce || HMAC(client_nonce) )
-    C->>D: SESS_KEY_NEG_FINISH (0x05) payload = HMAC(device_nonce)
+    C->>D: SESS_KEY_NEG_FINISH (0x05) payload = ENC( HMAC(device_nonce) )
     Note over C,D: Both sides derive session_key = AES_ECB_realKey( client_nonce XOR device_nonce )
 ```
-`HMAC = HMAC-SHA256(real_local_key, nonce)`.
+`HMAC = HMAC-SHA256(real_local_key, nonce)`; `ENC = AES-ECB(real_local_key, ...)`.
 
 Code reference: see `_negotiate_session_key_generate_step_1/3/finalize()` in `tinytuya/core/XenonDevice.py`.
 
 ### Session Key (Detailed)
 v3.4 derives a per-connection session key using a 3‑way exchange:
-1. Client -> Device (SESS_KEY_NEG_START / 0x03): 16‑byte client nonce (unencrypted payload).
+1. Client -> Device (SESS_KEY_NEG_START / 0x03): 16‑byte client nonce (AES‑ECB encrypted with the real local key).
 2. Device -> Client (SESS_KEY_NEG_RESP / 0x04): 16‑byte device nonce || HMAC-SHA256(client_nonce) encrypted with the real (static) local key (AES‑ECB).
-3. Client -> Device (SESS_KEY_NEG_FINISH / 0x05): HMAC-SHA256(device_nonce) (unencrypted payload).
+3. Client -> Device (SESS_KEY_NEG_FINISH / 0x05): HMAC-SHA256(device_nonce) (AES‑ECB encrypted with the real local key).
 
-Validation: Client recomputes `HMAC(client_nonce)` using real key and compares to bytes 16..48 of step 2 payload. If valid, it sends step 3 and both sides derive the session key.
+Validation: Client recomputes `HMAC(client_nonce)` using real key and compares to bytes 16..48 of the decrypted step 2 payload. If valid, it sends step 3 and both sides derive the session key.
 
 Derivation (3.4): XOR the two nonces byte-wise, AES-ECB encrypt with real key (no IV, no padding change) and use the full 16‑byte result as session key. (Implementation stores encrypted XOR directly.)
 
@@ -344,10 +350,10 @@ d.set_value(1, False)
 ### "Version Protocol" Source Header (v3.4)
 Because 3.4 encrypts the version header region, this source header (if present) is inside the AES-ECB encrypted payload:
 ```
-3.4CCCCCCCCSSSSSSSSUUUUUUUU
+3.4 | CRC32(4) | seq(4) | source id(4)
 ```
-* Same semantics as v3.3 (CRC / sequence / source id).
-* TinyTuya decrypts entire payload, then strips this source header, then the internal 3.x header if needed.
+* Same semantics as v3.3 (CRC / sequence / source id); 15 bytes total, occupying the same slot as the all-zeros version header.
+* TinyTuya decrypts the entire payload, then strips this 15-byte block (it does not parse the individual fields).
 
 ---
 ## Version 3.5
@@ -391,7 +397,7 @@ Properties:
 * Payload is NOT padded (GCM streaming block mode).
 * All multi‑byte integers big‑endian.
 * Entire payload (and optional retcode) is both encrypted and authenticated; header fields are only authenticated.
-* After decrypt: if first 4 bytes look like a plausible retcode (and next byte begins JSON `{`), library strips it before JSON decode.
+* After decrypt: for TCP data frames the library always strips the first 4 bytes as the retcode before JSON decode. (A `{`-lookahead heuristic exists only for UDP discovery decrypts, where the retcode may be absent.)
 
 `length` counts bytes from IV start through end of Tag (excludes footer).
 
@@ -400,7 +406,7 @@ Associated Data (AAD) exact formula:
 
 ### Session Key Handshake
 Same three-message flow / math as 3.4 except:
-* RESP (0x04) payload appears unencrypted (already GCM not yet active) or may be treated directly; TinyTuya only decrypts that step for 3.4.
+* All three messages travel as plaintext *inside* GCM-encrypted 6699 frames keyed with the real (static) local key — the frame layer itself provides the encryption, so no additional AES-ECB pass is applied to the payloads. TinyTuya only performs an explicit payload decrypt of RESP for 3.4; for 3.5 the frame decrypt has already exposed it.
 * Session key derivation uses AES-GCM with IV = first 12 bytes of client nonce and takes slice `[12:28]` of the result ciphertext+tag blob:
   ```python
   tmp = bytes(a^b for a,b in zip(device_nonce, client_nonce))
@@ -421,8 +427,8 @@ sequenceDiagram
 
 ### Session Key (Detailed)
 Both v3.4 and v3.5 share the nonce/HMAC pattern; v3.5 differs in how the final session key bytes are carved out:
-1. Client sends 16‑byte nonce (plain in START frame payload).
-2. Device responds with 16‑byte device nonce + HMAC-SHA256(client_nonce) (for 3.5 this arrives as plaintext inside 55AA or 6699 depending on implementation; TinyTuya handles it transparently).
+1. Client sends 16‑byte nonce (as the plaintext of a GCM-encrypted START frame).
+2. Device responds with 16‑byte device nonce + HMAC-SHA256(client_nonce) (for 3.5 this arrives inside a GCM-encrypted 6699 frame keyed with the real local key; the frame decrypt exposes it — TinyTuya handles it transparently).
 3. Client validates HMAC, returns HMAC-SHA256(device_nonce).
 
 Derivation (3.5): XOR the nonces -> encrypt with AES-GCM using real key and IV = first 12 bytes of client nonce; take bytes 12..28 of the resulting (IV||ciphertext||tag) buffer as the session key. This matches device behavior.
@@ -447,20 +453,20 @@ Notes:
 3. Return code (if present in responses) is decrypted first 4 bytes before JSON.
 
 ### DP Query / device22
-Device22 override still applies (CONTROL_NEW / DP_QUERY_NEW). Library wraps resulting JSON in GCM.
+Device22 command overrides still apply if `dev_type='device22'` was set manually or carried over (CONTROL_NEW / DP_QUERY_NEW), but the `data unvalid` auto-detection never fires on 3.5 (it is gated to 3.3/3.4). Library wraps resulting JSON in GCM.
 
 ### Retcode & Header Decode Order
 Typical decrypted ordering:
-`[retcode(4)] [source header?] [version header] { JSON }`
+`[retcode(4)] [version or source header (15B)] { JSON }`
+
+The version header and the source header occupy the same 15-byte slot (`3.5` + 12 bytes); a payload carries at most one of them.
 
 Pseudo-order logic (illustrative):
 ```text
-ptr=0
-ret = u32(payload[0:4]); ptr += 4
-if payload[ptr:ptr+2] == b'3.5' and looks_like_source_header(payload[ptr:ptr+24]):
-    source = payload[ptr:ptr+24]; ptr += 24
+ptr = 0
+ret = u32(payload[0:4]); ptr += 4   # retcode (always stripped for TCP frames)
 if payload[ptr:ptr+3] == b'3.5':
-    ptr += 15  # skip version header
+    ptr += 15  # skip 15-byte version/source header block
 json_bytes = payload[ptr:]
 ```
 Library handles this automatically.
@@ -476,21 +482,21 @@ d.set_value(1, True)
 ```
 
 ### "Version Protocol" Source Header (v3.5)
-Encrypted within the GCM ciphertext (after optional retcode). Layout unchanged:
+Encrypted within the GCM ciphertext (after the retcode). Layout unchanged:
 ```
-3.5CCCCCCCCSSSSSSSSUUUUUUUU
+3.5 | CRC32(4) | seq(4) | source id(4)
 ```
 Differences vs earlier versions:
-* Outer 6699 frame sequence is GLOBAL and independent; inner `SSSSSSSS` remains per source.
-* TinyTuya decrypts, strips retcode, then this header, then proceeds to JSON.
-* Same CRC zeroing for LAN; same small cache of recent `UUUUUUUU` identities.
+* Outer 6699 frame sequence is GLOBAL and independent; the inner sequence field remains per source.
+* TinyTuya decrypts, strips the retcode, then strips this 15-byte block, then proceeds to JSON.
+* Same CRC zeroing for LAN; same small cache of recent source ids.
 
 ### Discovery (v3.5)
 Two patterns:
 1. Broadcast (older 3.5) using 6699 GCM packet on UDP/6667.
 2. Solicited: Send client broadcast (UDP/7000) GCM-encrypted JSON: `{"from":"app","ip":"<your-ip>"}`. Device replies unicast (port 7000) encrypted.
 
-Broadcast encryption key = `MD5("yGAdlopoPVldABfn")` (16 bytes). Same key/IV rules as normal 3.5 packets (per-packet IV, Tag verify).
+Broadcast encryption key = `MD5("yGAdlopoPVldABfn")` (16 bytes). Same key/IV rules as normal 3.5 packets (per-packet IV, Tag verify). This is the same well-known key that decrypts the pre-3.5 AES-ECB broadcasts on UDP/6667; TinyTuya's `decrypt_udp()` transparently handles all three broadcast formats (raw AES-ECB blob, 55AA-framed plaintext or ECB payload, and 6699 GCM).
 
 Minimal listener (PyCryptodome):
 ```python
@@ -536,19 +542,20 @@ payload = json.dumps({"from":"app","ip":"YOUR_IP"}).encode()
 
 def pack6699(seq, cmd, raw):
     # Minimal 6699 pack for discovery (no retcode). Not production-hardened.
+    import os
     prefix = b'\x00\x00\x66\x99'
     reserved = b'\x00\x00'
     seq_b = seq.to_bytes(4,'big')
     cmd_b = cmd.to_bytes(4,'big')
-    # We'll generate IV, then fill length.
-    import os
     iv = os.urandom(12)
-    header_wo_prefix = reserved + seq_b + cmd_b + b'\x00\x00\x00\x00'  # temp length
-    cipher = AES.new(key, AES.MODE_GCM, nonce=iv)
-    cipher.update(header_wo_prefix)  # AAD excludes prefix per standard usage in library
-    ct, tag = cipher.encrypt_and_digest(raw)
-    length = (len(iv) + len(ct) + len(tag)).to_bytes(4,'big')
+    # GCM does not pad, so length (IV + ciphertext + tag) is known up front.
+    # The header MUST be built with the final length BEFORE encrypting,
+    # because the AAD must match the transmitted header bytes exactly.
+    length = (12 + len(raw) + 16).to_bytes(4,'big')
     header = prefix + reserved + seq_b + cmd_b + length
+    cipher = AES.new(key, AES.MODE_GCM, nonce=iv)
+    cipher.update(header[4:])  # AAD = header bytes after the prefix (as in the library)
+    ct, tag = cipher.encrypt_and_digest(raw)
     return header + iv + ct + tag + b'\x00\x00\x99\x66'
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -564,13 +571,13 @@ Listen on UDP/7000 for the unicast encrypted reply and decrypt with the same key
 |--------|---------|----------|
 | DP Query cmd | 0x0A (DP_QUERY) | 0x0D (CONTROL_NEW) override |
 | Required DPS list | Optional | Required (sent as null-valued map) |
-| Auto-detection | N/A | Triggered by `"data unvalid"` response on first attempt |
+| Auto-detection | N/A | Triggered by `"data unvalid"` response on first attempt (3.3/3.4 only; 3.2 is forced at `set_version()`, 3.5 never auto-detects) |
 
 TinyTuya sets `self.dev_type` and rebuilds internal payload dictionary accordingly.
 
 ---
 ## Sub-Devices / Gateways (Zigbee via Wi‑Fi Hub)
-* Uses `cid` (child id) inserted into JSON; gateway sets `dev_type='gateway'` plus child devices registered.
+* Uses `cid` (child id) inserted into JSON; the library selects gateway payload templates based on registered child devices (`self.children`), not a special `dev_type`.
 * 3.4/3.5 Zigbee control encloses `{ "protocol":5, "t":"int", "data":{"cid":"...","dps":{...}}}` inside encrypted payload.
 * Extended operations use `LAN_EXT_STREAM` (0x40) with `reqType` selectors (e.g. `subdev_online_stat_query`).
 
@@ -597,7 +604,7 @@ sequenceDiagram
     D-->>C: RESP (0x04) device_nonce||HMAC(client_nonce)
     C->>D: FINISH (0x05) HMAC(device_nonce)
     Note over C,D: Derive session_key
-    C->>D: DP_QUERY_NEW (0x10) (GCM, header+JSON encrypted)
+    C->>D: DP_QUERY_NEW (0x10) (GCM, JSON encrypted; no version header)
     D-->>C: Response (retcode + JSON encrypted)
     C->>D: CONTROL_NEW (0x0D) set dps
     D-->>C: Ack / updated state
@@ -659,8 +666,8 @@ Protocol reverse-engineering contributions by many in the community; specific 3.
 Below is a fabricated (shortened) hex frame for a v3.4 CONTROL_NEW command turning DP 1 on. Session key already negotiated.
 
 ```
-000055aa 0000002a 0000000d 00000058 
-        <ciphertext ... 48 bytes ...> 
+000055aa 0000002a 0000000d 00000074 
+        <ciphertext ... 80 bytes ...> 
 5f1c3a9b 7b1d2c0f 0000aa55
 ```
 
@@ -670,7 +677,7 @@ Breaking it down:
 | 000055aa | Prefix |
 | 0000002a | seq = 42 |
 | 0000000d | cmd = 0x0D CONTROL_NEW |
-| 00000058 | length (0x58 = 88) = payload+ciphertext + HMAC (32) + footer (4) [device->client would also include retcode field adjustment] |
+| 00000074 | length (0x74 = 116) = ciphertext (80) + HMAC (32) + footer (4) [device->client replies also count the 4‑byte retcode] |
 | …ciphertext… | AES‑ECB(session_key, padded( version_header + JSON )) |
 | 5f1c3a9b 7b1d2c0f | (first 8 bytes of 32‑byte HMAC-SHA256 shown) |
 | 0000aa55 | Footer |
@@ -683,28 +690,29 @@ Decrypted (after AES‑ECB & unpad) plaintext (pretty‑printed):
     "data": { "dps": { "1": true } }
 }
 ```
-The preceding bytes inside the ciphertext started with the 3.4 version header (`33 2e 34 00 ... 00` total 15 bytes) before the JSON.
+The plaintext inside the ciphertext started with the 3.4 version header (`33 2e 34 00 ... 00` total 15 bytes) followed by the compact 55‑byte JSON: 15 + 55 = 70 bytes, PKCS#7 padded to the 80‑byte ciphertext above.
 
 ### B. Version Protocol Source Header (v3.3 STATUS response)
-Sample leading bytes (ASCII) before JSON (unencrypted for 3.3):
+Sample leading bytes before JSON (unencrypted for 3.3), 15 bytes total:
 ```
-33 2e 33 30 30 30 30 30 30 30 30 30 41 42 30 30 30 30 30 30 30 30 30 32
-│ 3 │ . │ 3 │ 0 0 0 0 0 0 0 0 │ A B 0 0 │ 0 0 0 0 0 0 0 2 │
+33 2e 33 | 00 00 00 00 | 00 00 00 02 | 00 00 00 01
+  "3.3"    CRC32 = 0      seq = 2      source id = 1
 ```
 Interpreted:
-* `3.3` – version
-* `00000000` – CRC32 placeholder (LAN, zeroed)
-* `AB00` – high word of per-source sequence (example) continuing as `00000002` low portion (entire 8 hex chars sequence = `AB000000` then next 8 = `00000002` depending on formatting). (Illustrative only.)
-* `00000002` – source id (client #2)
+* `3.3` – ASCII version
+* `00000000` – CRC32 zeroed (LAN-sourced)
+* `00000002` – per-source sequence = 2
+* `00000001` – source id (the device itself)
 
-Immediately after this header the payload continues with (possibly encrypted) version header or JSON depending on version/command.
+Immediately after this 15-byte header the payload continues with the (possibly encrypted) JSON.
 
 ### C. 6699 Frame (v3.5 DP_QUERY_NEW response with retcode)
 Fabricated hex (grouped):
 ```
-00006699 0000 00000035 00000010 00000034 
+00006699 0000 00000035 00000010 00000057 
  1a2b3c4d5e6f708192a3b4c5  
-    d4c3b2a19081726355443322 00112233445566778899aabbccddeeff 112233445566778899aabbccddeeff
+    <ciphertext ... 59 bytes ...>
+    00112233445566778899aabbccddeeff
     00009966
 ```
 
@@ -714,27 +722,28 @@ Fabricated hex (grouped):
 | 0000 | Reserved/ignored |
 | 00000035 | seq (global) = 53 |
 | 00000010 | cmd = 0x10 DP_QUERY_NEW |
-| 00000034 | length (0x34=52) bytes from IV through Tag |
+| 00000057 | length (0x57 = 87) = IV (12) + ciphertext (59) + Tag (16); footer excluded |
 | 1a2b3c…c5 | 12‑byte IV/nonce |
-| d4c3…3322 | Ciphertext (first 12 bytes) – begins with encrypted retcode (4 bytes) then encrypted header/JSON |
-| 0011..eeff | More ciphertext (trimmed) |
-| 1122..eeff | 16‑byte GCM Tag |
+| …ciphertext… | 59 bytes (GCM, unpadded) – encrypted retcode (4) + 15‑byte header + 40‑byte JSON |
+| 0011..eeff | 16‑byte GCM Tag |
 | 00009966 | Footer |
 
-After AES‑GCM decrypt/tag verify using session key:
+After AES‑GCM decrypt/tag verify using session key (59 bytes plaintext):
 ```
-00000000 3378000000000000000000017b227d7d
-^^^^^^^^ retcode (0)
-                ^^^^^^^^^^^^^^^^^^^^^^^^ Version Protocol source header (example: 3.5 + zeros + src id 1)
-                                                                ^^^^^^^^ JSON begins
+00000000 | 33 2e 35  00000000  00000002  00000001 | 7b 22 64 70 73 ... 7d 7d
+retcode=0   "3.5"     CRC32=0    seq=2    srcid=1   JSON (40 bytes)
 ```
+* First 4 bytes: retcode (0 = success).
+* Next 15 bytes: Version Protocol source header (`3.5` + CRC32 + seq + source id).
+* Remaining 40 bytes: JSON.
+
 Decoded JSON (toy example):
 ```json
 {"dps":{"1":true,"20":123,"101":"blue"}}
 ```
 
 ### D. Mixed Ordering (3.5 CONTROL_NEW ack)
-Some responses: `retcode || source_header || version_header || JSON`. TinyTuya handles stripping in that order; if you craft tooling replicate the same parse sequence.
+Some responses: `retcode || header(15B) || JSON`, where the 15-byte block is either the all-zeros version header or the CRC/seq/source-id variant (never both). TinyTuya strips the retcode then the 15-byte block; if you craft tooling replicate the same parse sequence.
 
 ### E. Practical Hex Capture Tips
 1. Use `tcpdump -i <iface> -s 0 -X 'tcp port 6668'` (replace port if different) to capture.

--- a/README.md
+++ b/README.md
@@ -1046,7 +1046,7 @@ Example device: https://www.aliexpress.com/item/1005005034880204.html
 | 112  | Work log | byte str |||
 | 113  | Partition parameters | byte str |||
 | 114  | Work mode | enum | AutoMode/?? ||
-| 115  | Machine control CMD | enum | <ul><li>StartMowing</li><li>StartFixedMowing</li><li>PauseWork</li><li>CancelWork</li><li>StartReturnStation</li><ul> ||
+| 115  | Machine control CMD | enum | <ul><li>StartMowing</li><li>StartFixedMowing</li><li>PauseWork</li><li>CancelWork</li><li>StartReturnStation</li></ul> ||
 
 Reference [pymoebot](https://github.com/Whytey/pymoebot) for further definition.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ TinyTuya has a built-in setup Wizard that uses the Tuya IoT Cloud Platform to ge
         - Select the API Groups from the dropdown and click `Subscribe` ([screenshot](https://user-images.githubusercontent.com/38729644/128742724-9ed42673-7765-4e21-94c8-76022de8937a.png))
     * **RENEWAL:** The subscription to the `IoT Core` service expires after some time. By default, when you subscribe to it for the first time, it will last for one month. Once expired, the setup wizard won't be able to communicate with the Tuya account anymore, so it needs to be renewed. As of November 12th 2024, it can be renewed for a duration of 1, 3 or 6 months by simply filling in a form with some basic information (e.g. purpose of the project, type of developer).
 
-5. WIZARD - Run Setup Wizard:
+4. WIZARD - Run Setup Wizard:
     * From your Linux/Mac/Win PC run the TinyTuya Setup **Wizard** to fetch the *Local_Keys* for all of your registered devices:
       ```bash
       python -m tinytuya wizard   # use -nocolor for non-ANSI-color terminals
@@ -178,7 +178,7 @@ Classes
 TinyTuya Base Functions
     devices = deviceScan()                        # Returns dictionary of devices found on local network
     scan()                                        # Interactive scan of local network
-    wizard()                                      # Interactive setup wizard
+    wizard                                        # Interactive setup wizard (run via: python -m tinytuya wizard)
     set_debug(toggle, color)                      # Activate verbose debugging output
     pack_message(msg, hmac_key)                   # Packs a TuyaMessage(), encrypting or adding a CRC if required 
     unpack_message(data, hmac_key, header, 
@@ -192,7 +192,7 @@ TinyTuya Base Functions
  Device Functions (All Devices)
     json = status()                               # returns json payload
     subdev_query(nowait)                          # query sub-device status (only for gateway devices)
-    set_version(version)                          # 3.1 [default], 3.2, 3.3 or 3.4
+    set_version(version)                          # 3.1 [default], 3.2, 3.3, 3.4 or 3.5
     set_socketPersistent(False/True)              # False [default] or True
     set_socketNODELAY(False/True)                 # False or True [default]
     set_socketRetryLimit(integer)                 # retry count limit [default 5]
@@ -200,7 +200,7 @@ TinyTuya Base Functions
     set_socketTimeout(timeout)                    # set connection timeout in seconds [default 5]
     set_dpsUsed(dps_to_request)                   # add data points (DPS) to request
     add_dps_to_request(index)                     # add data point (DPS) index set to None
-    set_retry(retry=True)                         # retry if response payload is truncated
+    set_retry(retry)                              # retry if response payload is truncated
     set_status(on, switch=1, nowait)              # Set status of switch to 'on' or 'off' (bool)
     set_value(index, value, nowait)               # Set int value of any index.
     set_multiple_values(index_value_dict, nowait) # Set multiple values with a single request
@@ -208,7 +208,7 @@ TinyTuya Base Functions
     updatedps(index=[1], nowait)                  # Send updatedps command to device
     turn_on(switch=1, nowait)                     # Turn on device / switch #
     turn_off(switch=1, nowait)                    # Turn off
-    set_timer(num_secs, nowait)                   # Set timer for num_secs
+    set_timer(num_secs, dps_id=0, nowait)         # Set timer for num_secs on DPS dps_id (0=detect)
     set_sendWait(num_secs)                        # Time to wait after sending commands before pulling response
     detect_available_dps()                        # Return list of DPS available from device
     generate_payload(command, data,...            # Generate TuyaMessage payload for command with data
@@ -227,7 +227,7 @@ BulbDevice Additional Functions
     set_brightness_percentage(brightness=100, nowait):
     set_colourtemp(colourtemp, nowait):
     set_colourtemp_percentage(colourtemp=100, nowait):
-    set_scene(scene, nowait):                     # 1=nature, 3=rave, 4=rainbow
+    set_scene(scene, scene_data=None, nowait):    # 1=nature, 3=rave, 4=rainbow
     set_mode(mode='white', nowait):               # white, colour, scene, music
     result = brightness():
     result = colourtemp():
@@ -266,7 +266,7 @@ Cloud Functions
     getdps(deviceid)
     sendcommand(deviceid, commands [, uri])
     getconnectstatus(deviceid)
-    getdevicelog(deviceid, start=[now - 1 day], end=[now], evtype="1,2,3,4,5,6,7,8,9,10", size=100, params={})
+    getdevicelog(deviceid, start=[now - 1 day], end=[now], evtype="1,2,3,4,5,6,7,8,9,10", size=0 [all], max_fetches=50, params={})
       -> when start or end are negative, they are the number of days before "right now"
           i.e. "start=-1" is 1 day ago, "start=-7" is 7 days ago
           
@@ -325,7 +325,6 @@ if data:
 data = d.set_status(False, 4)
 if data:
     print('set_status() result %r' % data)
-    print('set_status() extra %r' % data[20:-8])
 
 """
 RGB Bulb Device
@@ -415,7 +414,7 @@ while(True):
     # Send keep-alive heartbeat
     if not data:
         print(" > Send Heartbeat Ping < ")
-    	d.heartbeat()
+        d.heartbeat()
 
     # NOTE If you are not seeing updates, you can force them - uncomment:
     # print(" > Send Request for Status < ")
@@ -702,7 +701,7 @@ tinytuya <command> [-debug] [-nocolor] [-h] [-yes] [-no-poll] [-device-file FILE
   Version
       tinytuya version
 
-        Prints the installed TinyTuya version, e.g.:  TinyTuya version: 1.18.0
+        Prints the installed TinyTuya version, e.g.:  TinyTuya version: 1.19.0
 
   Help
       tinytuya help
@@ -712,7 +711,7 @@ tinytuya <command> [-debug] [-nocolor] [-h] [-yes] [-no-poll] [-device-file FILE
 ```
 
 ### Scan Tool 
-The function `tinytuya.scan()` will listen to your local network (UDP 6666 and 6667) and identify Tuya devices broadcasting their Address, Device ID, Product ID and Version and will print that and their stats to stdout.  This can help you get a list of compatible devices on your network. The `tinytuya.deviceScan()` function returns all found devices and their stats (via dictionary result).
+The function `tinytuya.scan()` will listen to your local network (UDP 6666, 6667 and 7000) and identify Tuya devices broadcasting their Address, Device ID, Product ID and Version and will print that and their stats to stdout.  This can help you get a list of compatible devices on your network. The `tinytuya.deviceScan()` function returns all found devices and their stats (via dictionary result).
 
 You can run the scanner from the command line using these interactive commands:
   ```bash
@@ -745,7 +744,7 @@ You can run the scanner from the command line using these interactive commands:
   python -m tinytuya version
   ```
 
-By default, the scan functions will retry 15 times to find new devices. If you are not seeing all your devices, you can increase max_retries by passing an optional arguments (eg. 50 retries):
+By default, the scan functions will listen for about 18 seconds to find new devices. If you are not seeing all your devices, you can increase the scan time by passing an optional number of seconds (eg. 50 seconds):
 
   ```bash
   # command line
@@ -757,7 +756,7 @@ By default, the scan functions will retry 15 times to find new devices. If you a
   tinytuya.scan(50)
 
   # return payload of devices
-  devices = tinytuya.deviceScan(false, 50)
+  devices = tinytuya.deviceScan(False, 50)
   ```
 
 ## Troubleshooting
@@ -1046,7 +1045,8 @@ Example device: https://www.aliexpress.com/item/1005005034880204.html
 | 111  | Error log | byte str |||
 | 112  | Work log | byte str |||
 | 113  | Partition parameters | byte str |||
-| 114  | Work mode | enum | AutoMode/?? ||                                                                                                                           | 115  | Machine control CMD | enum | <ul><li>StartMowing</li><li>StartFixedMowing</li><li>PauseWork</li><li>CancelWork</li><li>StartReturnStation</li><ul> ||
+| 114  | Work mode | enum | AutoMode/?? ||
+| 115  | Machine control CMD | enum | <ul><li>StartMowing</li><li>StartFixedMowing</li><li>PauseWork</li><li>CancelWork</li><li>StartReturnStation</li><ul> ||
 
 Reference [pymoebot](https://github.com/Whytey/pymoebot) for further definition.
 
@@ -1134,7 +1134,8 @@ Note: (A) or (B) means channel A or channel B
 
 A user contributed module is available for this device in the [Contrib library](https://github.com/jasonacox/tinytuya/tree/master/tinytuya/Contrib):
 
-```python                                                                                                                                                                                                         from tinytuya.Contrib import WiFiDualMeterDevice
+```python
+from tinytuya.Contrib import WiFiDualMeterDevice
 
 wdm = WiFiDualMeterDevice.WiFiDualMeterDevice(
     dev_id='abcdefghijklmnop123456',

--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -23,14 +23,14 @@
   Functions
     Device(XenonDevice)
         json = status()                    # returns json payload
-        set_version(version)               # 3.1 [default] or 3.3
+        set_version(version)               # 3.1 [default], 3.2, 3.3, 3.4 or 3.5
         set_socketPersistent(False/True)   # False [default] or True
         set_socketNODELAY(False/True)      # False or True [default]
         set_socketRetryLimit(integer)      # retry count limit [default 5]
         set_socketTimeout(timeout)         # set connection timeout in seconds [default 5]
         set_dpsUsed(dps_to_request)        # add data points (DPS) to request
         add_dps_to_request(index)          # add data point (DPS) index set to None
-        set_retry(retry=True)              # retry if response payload is truncated
+        set_retry(retry)                   # retry if response payload is truncated
         set_status(on, switch=1, nowait)   # Set status of switch to 'on' or 'off' (bool)
         set_value(index, value, nowait)    # Set int value of any index.
         heartbeat(nowait)                  # Send heartbeat to device

--- a/tinytuya/__main__.py
+++ b/tinytuya/__main__.py
@@ -102,7 +102,7 @@ cred_group = subparsers['wizard'].add_argument_group( 'Cloud API Credentials', '
 cred_group.add_argument( '-credentials-file', help='JSON file to load/save Cloud credentials from/to [Default: %s]' % CONFIGFILE, metavar='FILE' )
 cred_group.add_argument( '-key', help='Cloud API Key to use' )
 cred_group.add_argument( '-secret', help='Cloud API Secret to use' )
-cred_group.add_argument( '-region', help='Cloud API Region to use', choices=('cn', 'eu', 'eu-w', 'in', 'us', 'us-e') )
+cred_group.add_argument( '-region', help='Cloud API Region to use', choices=('cn', 'eu', 'eu-w', 'in', 'sg', 'us', 'us-e') )
 cred_group.add_argument( '-device', help='One or more Device ID(s) to use', action='append', nargs='+' )
 
 subparsers['wizard'].add_argument( '-dry-run', help='Do not actually connect to the Cloud', action='store_true' )


### PR DESCRIPTION
## Documentation accuracy pass + agent guides

A full fact-check of README.md and PROTOCOL.md against the current code (v1.19.0), plus two new documents to guide future development.

### README.md (16 fixes)
- Fixed a `TabError` in the Monitor loop example and removed a leftover raw-bytes slice (`data[20:-8]`) that raises `TypeError` on the decoded-dict API — all 15 Python code blocks now compile
- `deviceScan(false, 50)` → `deviceScan(False, 50)`; scan duration documented as **seconds** (`scantime`), not "retries"
- Corrected `set_timer` / `set_scene` / `set_retry` / `getdevicelog` signatures; noted `wizard` is a module, not a function
- Added 3.5 to `set_version`, refreshed stale 1.18.0 output, added UDP 7000, renumbered setup steps, fixed two broken markdown table/fence blocks

### PROTOCOL.md (12 errors + 3 omissions)
- Session-key handshake (3.4/3.5): all three negotiation messages are **encrypted** under the real local key — previously described as plaintext
- Rewrote the "source header" section to match the implementation (single 15-byte block; the 24-hex-char ASCII parse described does not exist in the code)
- Added `DP_QUERY_NEW` to the version-header skip list; corrected device22 auto-detect scoping (3.3/3.4 only; unconditional for 3.2)
- Recomputed all three hex examples so lengths/tags/annotations are internally consistent; fixed the `pack6699()` AAD/length ordering
- Documented UDP 6666 plaintext broadcasts, the shared `MD5("yGAdlopoPVldABfn")` discovery key, and added `UDP_NEW`/`BOARDCAST_LPV34`/`REQ_DEVINFO` to the command table

### New documents
- **DESIGN.md** — architecture guide: package layout, class hierarchy, message flow, protocol version matrix, key design decisions, and a "Known Architectural Debt" section
- **AGENTS.md** — contributor/agent conventions: build/test/lint, Python 3.7–3.12 support, API-stability and error-handling rules, the Contrib pattern, docs-to-update map, safety rails

### Code (doc-adjacent one-liners)
- `__main__.py`: added `sg` to `-region` choices (Cloud and the interactive wizard already accept it; argparse rejected it)
- `__init__.py`: corrected stale `set_version`/`set_retry` docstrings

All 23 unit tests pass; `pylint -E` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
