### PR TITLE
docs: fix Mermaid parse error in PROTOCOL.md 3.5 diagram

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -604,7 +604,7 @@ sequenceDiagram
     D-->>C: RESP (0x04) device_nonce||HMAC(client_nonce)
     C->>D: FINISH (0x05) HMAC(device_nonce)
     Note over C,D: Derive session_key
-    C->>D: DP_QUERY_NEW (0x10) (GCM, JSON encrypted; no version header)
+    C->>D: DP_QUERY_NEW (0x10) (GCM, JSON encrypted, no version header)
     D-->>C: Response (retcode + JSON encrypted)
     C->>D: CONTROL_NEW (0x0D) set dps
     D-->>C: Ack / updated state


### PR DESCRIPTION
Fixes a Mermaid rendering error in the **Full 3.5 Control Flow** sequence diagram in `PROTOCOL.md`.

The `DP_QUERY_NEW` message text contained a semicolon:

```
C->>D: DP_QUERY_NEW (0x10) (GCM, JSON encrypted; no version header)
```

In Mermaid, `;` is a statement separator, so the parser split the message mid-line and then expected an arrow token — producing `Parse error on line 9 ... got 'NEWLINE'` and an *Unable to render rich display* box on GitHub. Replaced the semicolon with a comma.

The other two Mermaid diagrams in the file were checked and contain no semicolons in their message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)