### PR TITLE
Server: keep tuyalisten thread alive if send_discovery_request fails

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -329,10 +329,16 @@ def tuyalisten(port):
     while(running):
         if port == UDPPORTAPP and time.time() - last_broadcast > scanner.BROADCASTTIME:
             log.debug("Sending discovery request to all 3.5 devices on the network")
-            if HOST:
-                scanner.send_discovery_request(iface_list)
-            else:
-                scanner.send_discovery_request()
+            try:
+                if HOST:
+                    scanner.send_discovery_request(iface_list)
+                else:
+                    scanner.send_discovery_request()
+            except Exception as err:
+                # A transient error (e.g. network hiccup) must not kill this
+                # listener thread - otherwise 3.5 devices are never discovered
+                # again until the server is restarted.
+                log.error("Failed to send discovery request on port %d: %s", port, err)
             last_broadcast = time.time()
         try:
             data, addr = client.recvfrom(4048)


### PR DESCRIPTION
## Problem

`scanner.send_discovery_request()` in the `tuyalisten` loop of `server/server.py` runs outside any `try/except`. A single transient error (e.g. an `OSError` from a short network outage) kills the UDP listener thread for port 7000 (`UDPPORTAPP`) permanently — the exception propagates out of the thread function and the thread never comes back.

Since protocol 3.5 devices only announce themselves in response to these periodic discovery requests, they are never (re)discovered again until the server is restarted. Devices already in `deviceslist` keep working, but any 3.5 device that powers up later (or was offline when the thread died) stays undiscovered: `/status/{id}` returns an error for it and the web UI (e.g. `device_dps.html`) shows no data, while 3.3 devices keep working normally. This makes the failure hard to diagnose — the server looks healthy otherwise.

We hit this in production (LoxBerry TinyTuya plugin): after a nightly maintenance window, both 3.5 devices vanished from the server while the 3.3 devices kept publishing; a restart fixed it instantly.

## Fix

Wrap the call in `try/except` and log the error, so the thread survives transient failures and simply retries on the next `BROADCASTTIME` cycle.

## Test

Fault injection (monkeypatched `send_discovery_request` raising `OSError` on calls 2 and 3):
- **Without the patch**: `Exception in thread Thread-3 (tuyalisten)` after the 2nd call, no further discovery requests are sent, 3.5 devices are lost after the next power cycle.
- **With the patch**: both failures are logged (`Failed to send discovery request on port 7000: [Errno 101] ...`), the thread keeps running and discovery resumes on the next cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)