### PR TITLE
server: bump to p17 — keep tuyalisten UDP discovery thread alive

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -113,6 +113,10 @@ The UI at http://localhost:8888 allows you to view and control the devices.
 
 ## Release Notes
 
+### p17 - Keep tuyalisten UDP Discovery Thread Alive
+
+* Wrapped `send_discovery_request()` in a `try/except` block so transient network errors (e.g. `OSError` during a brief outage) no longer kill the UDP listener thread permanently. Protocol 3.5 devices are now rediscovered after network interruptions without requiring a server restart. Fixes #726. (Credit: @mschlenstedt)
+
 ### p16 - Device File and Error Handling
 
 * Use centralized `tinytuya.load_devicefile()` to load `devices.json`, supporting both flat list and `{"devices": [...]}` wrapper formats. Fixes issue #532.

--- a/server/server.py
+++ b/server/server.py
@@ -72,7 +72,7 @@ except:
 import tinytuya
 from tinytuya import scanner
 
-BUILD = "p16"
+BUILD = "p17"
 
 # Defaults from Environment
 APIPORT = int(os.getenv("APIPORT", "8888"))


### PR DESCRIPTION
Companion to #726 (mschlenstedt's fix).

## Changes

- `server/server.py`: `BUILD = "p16"` → `"p17"`
- `server/README.md`: added p17 release notes

## Release Notes Entry

### p17 - Keep tuyalisten UDP Discovery Thread Alive

Wraps `send_discovery_request()` in a `try/except` so transient network errors (e.g. `OSError` during a brief outage) no longer kill the UDP listener thread permanently. Protocol 3.5 devices are now rediscovered after network interruptions without requiring a server restart.

Merge #726 first, then this.

— Sam ⚙️